### PR TITLE
Add support for modules

### DIFF
--- a/archetypes/modules.md
+++ b/archetypes/modules.md
@@ -1,0 +1,10 @@
+---
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+wiki: 'http://open-emr.org/wiki/PUT-LINK-HERE'
+minimum_version: 1.2.3(p)
+categories:
+  - CATEGORY-HERE
+---
+Write description here
+<!--more-->

--- a/content/modules/fax-sms.md
+++ b/content/modules/fax-sms.md
@@ -3,6 +3,7 @@ title: "Fax SMS"
 date: 2021-12-31T09:37:50-08:00
 wiki: 'https://community.open-emr.org/t/v2-2-0-fax-sms-module-released/16157'
 minimum_version: 5.0.2
+draft: true
 categories:
   - telecom
   - fax

--- a/content/modules/fax-sms.md
+++ b/content/modules/fax-sms.md
@@ -1,0 +1,12 @@
+---
+title: "Fax SMS"
+date: 2021-12-31T09:37:50-08:00
+wiki: 'https://community.open-emr.org/t/v2-2-0-fax-sms-module-released/16157'
+minimum_version: 5.0.2
+categories:
+  - telecom
+  - fax
+  - sms
+---
+Fax and SMS feature for OpenEMR
+<!--more-->

--- a/content/modules/lifemesh.md
+++ b/content/modules/lifemesh.md
@@ -1,0 +1,10 @@
+---
+title: "Lifemesh"
+date: 2021-12-31
+wiki: 'https://www.open-emr.org/wiki/index.php/OpenEMR_Modules#Telehealth'
+minimum_version: '6.0.0 (3)'
+categories:
+  - telehealth
+---
+Lifemesh Telehealth Module is a subscription service.
+<!--more-->

--- a/themes/openemr/layouts/modules/list.html
+++ b/themes/openemr/layouts/modules/list.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<main class="page container lectures-list">
+  <div class="row">
+    <div class="col-xs-12 col-md-8 offset-md-2">
+        <h1>OpenEMR Modules</h1>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="col-xs-12 col-md-8 offset-md-2 list-unstyled">
+      {{ range .Pages }}
+      <li class="border-bottom">
+        <h2>
+          <a href="{{ .Params.wiki }}" target="_blank">{{ .Title }}</a>
+          
+        </h2>
+        <div class="d-block">
+          <p class="p-0 m-0 text-secondary">
+            <span class="fw-bolder">Categories:&nbsp;</span>
+            {{ range .Params.categories }}
+            <span class="badge badge-primary rounded-pill">{{ . }}</span>
+          {{ end}}
+          </p>
+          <p class="text p-0 m-0 text-secondary">Requires OpenEMR version &ge; {{ .Params.minimum_version }}</p>
+          <p class="lead p-0">{{ .Summary }}</p>
+        </div>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+</main>
+{{ end }}
+

--- a/themes/openemr/layouts/modules/single.html
+++ b/themes/openemr/layouts/modules/single.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+<main class="page container lectures-list">
+  <div class="row">
+    <div class="col-xs-12 col-md-8 offset-md-2">
+        <h1>{{ .Title }}</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12 col-md-8 offset-md-2">
+      <p class="p-0 m-0 text-secondary">
+        <span class="fw-bolder">Categories:&nbsp;</span>
+        {{ range .Params.categories }}
+        <span class="badge badge-primary rounded-pill">{{ . }}</span>
+        {{ end }}
+      </p>
+      <p class="text p-0 m-0 text-secondary">Requires OpenEMR version &ge; {{ .Params.minimum_version }}</p>
+      <p class="lead p-0">{{ .Summary }}</p>
+    </div>
+  </div>
+</main>
+{{ end }}
+

--- a/themes/openemr/layouts/partials/navigation.html
+++ b/themes/openemr/layouts/partials/navigation.html
@@ -14,13 +14,7 @@
         <li><a href="{{ "wiki/index.php/OpenEMR_Features" | absURL }}">Features</a></li>
         <li><a href="{{ .Site.Params.demoURL | absURL }}">Demo</a></li>
         <li><a href="{{ "wiki/index.php/OpenEMR_Downloads" | absURL }}">Download</a></li>
-        <li class="nav-item dropdown">
-          <a href="" class="nav-link dropdown-toggle" id="modulesDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Modules</a>
-          <div class="dropdown-menu" aria-labelledby="modulesDropdownMenuLink">
-            <div class="arrow-up"></div>
-            <a class="dropdown-item" href="{{ "/wiki/index.php/OpenEMR_Modules#Telehealth" }}">Telehealth</a>
-          </div>
-        </li>
+        <li><a href="{{ "modules" | absURL }}" >Modules</a></li>
         <li><a href="{{ "blog" | absURL }}">Blog</a></li>
         <li><a href="{{ "wiki" | absURL}}">Docs</a></li>
         <li><a href="https://community.open-emr.org/">Forum</a></li>


### PR DESCRIPTION
`hugo new modules/name-of-module.md` will generate a skeleton file for easy management.

name-of-module.md should contain:
```md
---
title: "Name of the Module"
date: 2021-12-31 (This is unused at the momemt)
wiki: 'Link to the documentation for the module'
minimum_version: 6.1.0(3) (Patch in parenthesis)
categories:
  - list
  - of
  - categories
  - must
  - have
  - at
  - least
  - one
---
A brief description of the module here.
```

Main nav "Modules" item is no longer a drop down. Links to the list. Screenshot:

![image](https://user-images.githubusercontent.com/1381170/147834570-c2e34f63-4bd0-4852-8512-13ca5f65d9ef.png)
