### PR TITLE
Move main menu to config for better theme management

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ menu:
   main:
     - identifier: features
       name: Features
-      url: http://localhost:1313/wiki/index.php/OpenEMR_Features
+      url: /wiki/index.php/OpenEMR_Features
       weight: 1
     - identifier: demo
       name: Demo
@@ -24,7 +24,7 @@ menu:
       weight: 2
     - identifier: download
       name: Download
-      url: http://localhost:1313/wiki/index.php/OpenEMR_Downloads
+      url: /wiki/index.php/OpenEMR_Downloads
       weight: 3
     - identifier: module
       name: Modules
@@ -44,7 +44,7 @@ menu:
       weight: 7
     - identifier: chat
       name: Chat
-      url: http://localhost:1313/chat
+      url: /chat
       weight: 8
     - identifier: support
       name: Support
@@ -62,7 +62,7 @@ menu:
     - identifier: chat_support
       parent: support
       name: Chat
-      url: http://localhost:1313/chat
+      url: /chat
       weight: 3
     - identifier: psv
       parent: support
@@ -111,3 +111,7 @@ params:
   downloadUrl: https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads
 permalinks:
   post: /:filename/
+module:
+  # replacements: "github.com/providencehealthtech/hugo-hero-theme -> ../../hugo-hero-theme"
+  # imports:
+    # - path: github.com/google/docsy

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,75 @@ ignoreFiles:
 taxonomies:
   tag: ""
   category: ""
+menu:
+  main:
+    - identifier: features
+      name: Features
+      url: http://localhost:1313/wiki/index.php/OpenEMR_Features
+      weight: 1
+    - identifier: demo
+      name: Demo
+      url: /demo
+      weight: 2
+    - identifier: download
+      name: Download
+      url: http://localhost:1313/wiki/index.php/OpenEMR_Downloads
+      weight: 3
+    - identifier: module
+      name: Modules
+      url: /modules
+      weight: 4
+    - identifier: blog
+      name: Blog
+      url: /blog
+      weight: 5
+    - identifier: wiki
+      name: Docs
+      url: /wiki
+      weight: 6
+    - identifier: forum
+      name: Forum
+      url: https://community.open-emr.org/
+      weight: 7
+    - identifier: chat
+      name: Chat
+      url: http://localhost:1313/chat
+      weight: 8
+    - identifier: support
+      name: Support
+      weight: 9
+    - identifier: cost_and_support
+      parent: support
+      name: Costs and Support Options
+      url: /support
+      weight: 1
+    - identifier: community_support
+      parent: support
+      name: Community Support
+      weight: 2
+      url: https://community.open-emr.org
+    - identifier: chat_support
+      parent: support
+      name: Chat
+      url: http://localhost:1313/chat
+      weight: 3
+    - identifier: psv
+      parent: support
+      name: Professional Support Vendors
+      url: /wiki/index.php/Professional_Support
+      weight: 4
+    - identifier: howto
+      parent: support
+      name: How-To Guides
+      url: /wiki/index.php/OpenEMR_5.0.1_Users_Guide
+      weight: 5
+    - identifier: donate
+      name: Donate
+      weight: 10
+      url: /give
+      pre: '<i class="fa fa-heart fa-sm"></i>&nbsp;'
+      params:
+        anchorClass: 'btn btn-danger btn-sm mx-4'
 params:
   # Required theme-specific variables
   twitterImage: /images/test.jpg

--- a/themes/openemr/layouts/partials/navigation.html
+++ b/themes/openemr/layouts/partials/navigation.html
@@ -1,43 +1,42 @@
 <nav class="main-header default-state {{ with .IsHome }}home{{ end }}" id="main-navigation">
   <div class="container">
-    <a class="navbar-brand" href="{{ .Site.BaseURL }}">
+    <a class="navbar-brand ms-3" href="{{ .Site.BaseURL }}">
       <img src="data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='855.721' height='163.794'%3E%3Cg fill='%23fff'%3E%3Cpath d='M226.352 69.171c0 15.076 9.238 25.272 22.919 25.272 13.508 0 22.92-10.283 22.92-25.272 0-15.076-9.412-25.272-22.92-25.272-13.681-.088-22.919 10.196-22.919 25.272m72.158-.348c0 28.06-19.87 46.97-49.239 46.97-29.541 0-49.41-18.997-49.41-46.97 0-28.236 19.869-46.797 49.41-46.797 29.37-.088 49.239 18.561 49.239 46.797M377.115 68.474c0-14.727-9.238-25.272-22.746-25.272-13.506 0-22.918 10.457-22.918 25.272 0 15.25 9.412 25.447 22.918 25.447 13.508 0 22.746-10.371 22.746-25.447m26.666.872c0 27.887-16.906 46.536-42.701 46.536-12.81 0-22.919-5.141-29.543-14.38v46.536H305.22V22.808h26.317v13.509c6.536-9.236 16.558-14.38 29.02-14.38 25.795 0 43.224 19 43.224 47.409M477.507 61.328c-.35-12.113-8.192-20.044-20.305-20.044-11.59 0-19.52 7.844-21.525 20.044zM502.17 76.84H436.2c3.049 11.59 11.938 18.475 23.789 18.475 8.715 0 16.907-3.399 23.268-9.76l13.857 14.03c-9.238 10.283-22.746 16.21-39.302 16.21-29.37 0-48.02-18.824-48.02-46.711 0-28.41 19.349-47.145 47.322-47.145 32.244 0 47.234 21.437 45.054 54.901M600.644 56.97v57.778h-26.317V64.64c0-11.59-6.798-18.824-18.127-18.824-13.159.175-21.003 10.11-21.003 23.617v45.315H508.88V22.809h26.317v16.035c6.536-11.416 17.43-16.905 31.808-17.08 20.48 0 33.639 13.681 33.639 35.207'/%3E%3Cpath d='M341.821 132.264h351.721v7.146h-351.72zM199.86 132.264h94.901v7.146H199.86zM774.588 139.324h74.596l6.45-7.06h-81.046z'/%3E%3Cpath d='M729.62 161.023L693.63 46.339v93.072h-9.848V24.029h12.81l33.029 108.932L762.56 24.03h12.637v115.295h-9.761V46.252zM623.302 34.051V63.77h45.578v9.934h-45.578v30.936h52.637v9.848h-63.007V24.03h61.264v9.936h-50.894zM819.032 75.969c16.384 0 25.708-7.234 25.708-21.264 0-13.682-9.324-20.654-25.708-20.654h-23.965V75.97zm6.1 9.673c-1.916.087-4.01.261-6.1.261h-23.965V114.4h-10.284V24.03h34.336c22.57 0 35.644 11.068 35.644 30.328 0 14.989-7.235 25.01-20.219 29.28l21.177 30.676h-11.765zM132.82 49.792c-7.826-19.464-26.9-33.173-49.146-33.173-29.229 0-52.96 23.733-52.96 52.96 0 3.104.258 6.208.776 9.183a68.08 68.08 0 0 1-1.294-13.191C30.196 29.359 59.554 0 95.766 0c27.16 0 50.439 16.49 60.398 40.028.647 1.551 1.035 3.232 1.035 4.98 0 6.983-5.627 12.61-12.61 12.61-5.367.063-9.894-3.234-11.77-7.826'/%3E%3Cpath d='M67.702 135.668c19.27 8.211 42.485 4.396 58.198-11.317 20.693-20.694 20.693-54.254 0-74.947a55.4 55.4 0 0 0-7.048-5.949 65.785 65.785 0 0 1 10.281 8.406c25.608 25.608 25.608 67.123 0 92.73-19.205 19.205-47.334 23.99-71.001 14.42a13.906 13.906 0 0 1-4.268-2.78c-4.915-4.916-4.915-12.933 0-17.849a12.613 12.613 0 0 1 13.838-2.714'/%3E%3Cpath d='M28.127 50.697c-8.213 19.27-4.397 42.485 11.317 58.2 20.692 20.691 54.253 20.691 74.945 0a55.336 55.336 0 0 0 5.95-7.05 65.747 65.747 0 0 1-8.406 10.282c-25.608 25.607-67.122 25.607-92.73 0C-.003 92.924-4.787 64.795 4.783 41.127a13.87 13.87 0 0 1 2.78-4.268c4.915-4.914 12.934-4.914 17.848 0a12.612 12.612 0 0 1 2.716 13.838'/%3E%3Cpath d='M132.82 49.792c-7.826-19.464-26.9-33.173-49.146-33.173-29.229 0-52.96 23.733-52.96 52.96 0 3.104.258 6.208.776 9.183a68.08 68.08 0 0 1-1.294-13.191C30.196 29.359 59.554 0 95.766 0c27.16 0 50.439 16.49 60.398 40.028.647 1.551 1.035 3.232 1.035 4.98 0 6.983-5.627 12.61-12.61 12.61-5.367.063-9.894-3.234-11.77-7.826'/%3E%3Cpath d='M67.702 135.668c19.27 8.211 42.485 4.396 58.198-11.317 20.693-20.694 20.693-54.254 0-74.947a55.4 55.4 0 0 0-7.048-5.949 65.785 65.785 0 0 1 10.281 8.406c25.608 25.608 25.608 67.123 0 92.73-19.205 19.205-47.334 23.99-71.001 14.42a13.906 13.906 0 0 1-4.268-2.78c-4.915-4.916-4.915-12.933 0-17.849a12.613 12.613 0 0 1 13.838-2.714'/%3E%3Cpath d='M28.127 50.697c-8.213 19.27-4.397 42.485 11.317 58.2 20.692 20.691 54.253 20.691 74.945 0a55.336 55.336 0 0 0 5.95-7.05 65.747 65.747 0 0 1-8.406 10.282c-25.608 25.607-67.122 25.607-92.73 0C-.003 92.924-4.787 64.795 4.783 41.127a13.87 13.87 0 0 1 2.78-4.268c4.915-4.914 12.934-4.914 17.848 0a12.612 12.612 0 0 1 2.716 13.838M199.86 132.264h94.901v7.146H199.86z'/%3E%3C/g%3E%3C/svg%3E" height="25">
       <span class="sr-only">OpenEMR</span>
     </a>
     <button aria-controls="navbarSupportedContent" aria-expanded="false" id="dropdownMenuLink"
       aria-label="Toggle navigation" class="navbar-toggler"
       data-target="#navbarSupportedContent" data-toggle="collapse" type="button">
-      <i class="fa fa-bars fa-inverse fa-lg"></i>
+      <i class="fa fa-bars fa-inverse"></i>
     </button>
     <div id="navbarSupportedContent">
       <ul>
-        <li><a href="{{ "wiki/index.php/OpenEMR_Features" | absURL }}">Features</a></li>
-        <li><a href="{{ .Site.Params.demoURL | absURL }}">Demo</a></li>
-        <li><a href="{{ "wiki/index.php/OpenEMR_Downloads" | absURL }}">Download</a></li>
-        <li><a href="{{ "modules" | absURL }}" >Modules</a></li>
-        <li><a href="{{ "blog" | absURL }}">Blog</a></li>
-        <li><a href="{{ "wiki" | absURL}}">Docs</a></li>
-        <li><a href="https://community.open-emr.org/">Forum</a></li>
-        <li><a href="{{ "chat" | absURL }}">Chat</a></li>
-        <li class="nav-item dropdown">
-          <a href="" class="nav-link dropdown-toggle" id="supportDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Support</a>
-          <div class="dropdown-menu" aria-labelledby="supportDropdownMenuLink">
-            <div class="arrow-up"></div>
-            <a class="dropdown-item" href="/support">Costs and Support Options</a>
-            <a class="dropdown-item" href="https://community.open-emr.org/">Community Support</a>
-            <a class="dropdown-item" href="/chat">Free Basic Live Chat Support</a>
-            <a class="dropdown-item" href="{{ "/wiki/index.php/Professional_Support" | absURL }}">Professional Support Vendors</a>
-            <a class="dropdown-item" href="{{ "/wiki/index.php/OpenEMR_5.0.1_Users_Guide" | absURL }}">How-to Guides</a>
-          </div>
-        </li>
+        {{ $currentPage := . }}
+        {{ range .Site.Menus.main.ByWeight }}
+          {{ if .HasChildren }}
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" id="supportDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ .Name }}</a>
+              <div class="dropdown-menu" aria-labelledby="supportDropdownMenuLink">
+                <div class="arrow-up"></div>
+                {{ range .Children }}
+                  <a href="{{ .URL }}" class="dropdown-item {{ .Params.anchorClass }}">{{ .Pre }}{{ .Name }}</a>
+                {{ end }}
+              </div>
+            </li>
+          {{ else }}
+            <li class="nav-item">
+              <a href="{{ .URL }}" class='{{ .Params.anchorClass }}{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}'>{{ .Pre }}{{ .Name }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
         {{ with .Site.Params.github }}
         <li>
           <a class="nav-item github" href="{{ . }}">
             <i class="fa fa-github"></i>
+            <span class="sr-only">Github</span>
           </a>
         </li>
         {{ end }}
-        <li><a href="{{ "donate" | absURL }}" class="btn btn-danger btn-sm"><i class="fa fa-heart fa-fw"></i>&nbsp;Donate</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Current theme hard-codes the main menu. This PR abstracts the menu into the config file (a best practice in Hugo) and makes the rendering easier. No aesthetic changes, all "backend" stuff