### PR TITLE
corrected colors to 4.5 contrast for WCAG

### DIFF
--- a/themes/openemr/assets/scss/_gt.scss
+++ b/themes/openemr/assets/scss/_gt.scss
@@ -29,7 +29,7 @@
         }
 
         a {
-            color: hsl(0, 100, 100);
+            color: #111111;
             &:hover {
                 text-decoration: none !important;
             }

--- a/themes/openemr/assets/scss/_gt.scss
+++ b/themes/openemr/assets/scss/_gt.scss
@@ -29,7 +29,7 @@
         }
 
         a {
-            color: #111111;
+            color: $gray-900;
             &:hover {
                 text-decoration: none !important;
             }

--- a/themes/openemr/assets/scss/_jumbotron.scss
+++ b/themes/openemr/assets/scss/_jumbotron.scss
@@ -195,10 +195,6 @@
     }
 }
 
-i.fa-heart {
-    color: white;
-}
-
 .welcome-billboard {
   @extend .home-billboard;
   height: 500px;

--- a/themes/openemr/assets/scss/_jumbotron.scss
+++ b/themes/openemr/assets/scss/_jumbotron.scss
@@ -9,7 +9,7 @@
             left: 0;
             height: 100%;
             width: 100%;
-            background-color: rgba(0,0,0,0.5);
+            background-color: rgba(0,0,0,0.3);
         }
     }
 
@@ -63,8 +63,7 @@
                     @extend .text-start;
                     @extend .bg-primary;
                     @extend .mb-2;
-                    //background-color: rgba(46, 155, 214, 0.40) !important;
-                    background-color: rgba(255, 255, 255, 0.20) !important;
+                    background-color: #335489 !important;
                     transition: background-color 0.25s;
 
                     h4 {
@@ -81,7 +80,7 @@
 
                     &:hover {
                         @include transition(0.25s);
-                        background-color: rgb(46, 155, 214) !important;
+                        background-color: #4975BC !important;
                     }
                     a {
                         color: $white;
@@ -196,6 +195,9 @@
     }
 }
 
+i.fa-heart {
+    color: white;
+}
 
 .welcome-billboard {
   @extend .home-billboard;

--- a/themes/openemr/assets/scss/_nav.scss
+++ b/themes/openemr/assets/scss/_nav.scss
@@ -32,7 +32,7 @@
     a {
         color: $white !important;
         &:hover {
-            color: lighten($blue, 50) !important;
+            color: lighten($blue, 60) !important;
         }
     }
 }

--- a/themes/openemr/layouts/index.html
+++ b/themes/openemr/layouts/index.html
@@ -14,7 +14,7 @@
                     <div class="card donation">
                         <a href="{{ .Site.BaseURL }}donate/">
                             <div class="card-body">
-                                <i class="fa fa-heart fa-4x float-left me-4"></i>
+                                <i class="text-white fa fa-heart fa-4x float-left me-4"></i>
                                 <h4 class="card-title">Give Now</h4>
                                 <div class="card-body">Help support future development of OpenEMR</div>
                             </div>


### PR DESCRIPTION
Description

Users can see links from the navigation bar, side content, and the donation link with accessible contrast including when hovering.   

I used the WebAIM contrast checker: https://webaim.org/resources/contrastchecker/ and pulled colors using ColorZilla as well as Chrome Developer Tools.

Video Link

https://www.loom.com/share/7246e61bbc6f41e691fc152a1c87aa82

Type of change
- [X]  Bug Fix 

Tasks Completed
- [X] adjusted the text color for the donation link text to be dark,( the green background is so bright that #fff does not meet WCAG contrast )
- [X] I adjusted the navigation bar hover text to maintain a higher level of contrast so that users can still see the text they are selecting.
- [X] I adjusted the demo card div background color to maintain WCAG contrast of at least 4.5

Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
