### PR TITLE
enhance: Make footer menus configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -148,7 +148,7 @@ menu:
       weight: 60
       url: https://open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#ONC_Ambulatory_EHR_Certification
     - identifier: ack
-      name: Acknowledgments
+      name: Acknowledgements
       weight: 70
       url: https://open-emr.org/wiki/index.php/OpenEMR_Acknowledgments
   footer_three:

--- a/config.yaml
+++ b/config.yaml
@@ -81,6 +81,92 @@ menu:
       pre: '<i class="fa fa-heart fa-sm"></i>&nbsp;'
       params:
         anchorClass: 'btn btn-danger btn-sm mx-4'
+  footer_one:
+    - identifier: features
+      name: Features
+      weight: 10
+      url: /wiki/index.php/OpenEMR_Features
+    - identifier: demo
+      name: Demo
+      weight: 20
+      url: demo
+    - identifier: download 
+      name: Download
+      weight: 30
+      url: /wiki/index.php/OpenEMR_Downloads
+    - identifier: modules
+      name: Modules
+      weight: 40
+      url: /wiki/index.php/OpenEMR_Modules
+    - identifier: blog
+      name: Blog
+      weight: 50
+      url: blog
+    - identifier: docs
+      name: Docs
+      weight: 60
+      url: /wiki
+    - identifier: forum
+      name: Forum
+      weight: 70
+      url: https://community.open-emr.org/
+    - identifier: chat
+      name: Chat
+      weight: 80
+      url: chat
+    - identifier: donate
+      name: Donate
+      weight: 90
+      url: donate
+    - identifier: support
+      name: Support
+      weight: 100
+      url: support
+  footer_two:
+    - identifier: faq
+      name: FAQ
+      weight: 10
+      url: /wiki/index.php/FAQ
+    - identifier: forum
+      name: Forum
+      weight: 20
+      url: https://community.open-emr.org/
+    - identifier: user_manuals
+      name: User Manuals
+      weight: 30
+      url: /wiki/index.php/OpenEMR_Wiki_Home_Page#User_Manual
+    - identifier: support_guide
+      name: Support Guide
+      weight: 40
+      url: /support
+    - identifier: professional_support
+      name: Professional Support
+      weight: 50
+      url: /wiki/index.php/OpenEMR_Professional_Support
+    - identifier: onc
+      name: Certification
+      weight: 60
+      url: /wiki/index.php/OpenEMR_Wiki_Home_Page#ONC_Ambulatory_EHR_Certification
+    - identifier: ack
+      name: Acknowledgments
+      weight: 70
+      url: /wiki/index.php/OpenEMR_Acknowledgments
+  footer_three:
+    - identifier: dev_guide
+      name: Developer Manuals
+      weight: 10
+      pre: '<i class="fa fa-book"></i>&nbsp;'
+      url: /wiki/index.php/OpenEMR_Development
+    - identifier: issues
+      name: Issues
+      weight: 20
+      pre: '<i class="fa fa-bug"></i>&nbsp;'
+      url: https://github.com/openemr/issues
+    - identifier: github
+      name: GitHub
+      weight: 40
+      pre: '<i class="fa fa-github"></i>&nbsp;'
+      url: "https://github.com/openemr"
 params:
   # Required theme-specific variables
   twitterImage: /images/test.jpg
@@ -112,5 +198,8 @@ params:
     twitter: openemr
   demoUrl: demo
   downloadUrl: https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads
+  footer_one_title: Main Project Links
+  footer_two_title: Help & Support Links
+  footer_three_title: Developer Links
 permalinks:
   post: /:filename/

--- a/config.yaml
+++ b/config.yaml
@@ -85,7 +85,7 @@ menu:
     - identifier: features
       name: Features
       weight: 10
-      url: /wiki/index.php/OpenEMR_Features
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Features
     - identifier: demo
       name: Demo
       weight: 20
@@ -93,11 +93,11 @@ menu:
     - identifier: download 
       name: Download
       weight: 30
-      url: /wiki/index.php/OpenEMR_Downloads
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Downloads
     - identifier: modules
       name: Modules
       weight: 40
-      url: /wiki/index.php/OpenEMR_Modules
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Modules
     - identifier: blog
       name: Blog
       weight: 50
@@ -105,7 +105,7 @@ menu:
     - identifier: docs
       name: Docs
       weight: 60
-      url: /wiki
+      url: https://open-emr.org/wiki
     - identifier: forum
       name: Forum
       weight: 70
@@ -126,7 +126,7 @@ menu:
     - identifier: faq
       name: FAQ
       weight: 10
-      url: /wiki/index.php/FAQ
+      url: https://open-emr.org/wiki/index.php/FAQ
     - identifier: forum
       name: Forum
       weight: 20
@@ -134,7 +134,7 @@ menu:
     - identifier: user_manuals
       name: User Manuals
       weight: 30
-      url: /wiki/index.php/OpenEMR_Wiki_Home_Page#User_Manual
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#User_Manual
     - identifier: support_guide
       name: Support Guide
       weight: 40
@@ -142,26 +142,26 @@ menu:
     - identifier: professional_support
       name: Professional Support
       weight: 50
-      url: /wiki/index.php/OpenEMR_Professional_Support
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Professional_Support
     - identifier: onc
       name: Certification
       weight: 60
-      url: /wiki/index.php/OpenEMR_Wiki_Home_Page#ONC_Ambulatory_EHR_Certification
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#ONC_Ambulatory_EHR_Certification
     - identifier: ack
       name: Acknowledgments
       weight: 70
-      url: /wiki/index.php/OpenEMR_Acknowledgments
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Acknowledgments
   footer_three:
     - identifier: dev_guide
       name: Developer Manuals
       weight: 10
       pre: '<i class="fa fa-book"></i>&nbsp;'
-      url: /wiki/index.php/OpenEMR_Development
+      url: https://open-emr.org/wiki/index.php/OpenEMR_Development
     - identifier: issues
       name: Issues
       weight: 20
       pre: '<i class="fa fa-bug"></i>&nbsp;'
-      url: https://github.com/openemr/issues
+      url: https://github.com/openemr/openemr/issues
     - identifier: github
       name: GitHub
       weight: 40

--- a/themes/openemr/layouts/index.html.html
+++ b/themes/openemr/layouts/index.html.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-
 <section class="billboard billboard__home billboard__home--giving-tuesday">
     <div class="row">
         <div class="content">

--- a/themes/openemr/layouts/partials/footer.html
+++ b/themes/openemr/layouts/partials/footer.html
@@ -8,52 +8,27 @@
         </a>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
-        <h5 class="title nowiki">Main Project Links</h5>
+        <h5 class="title nowiki">{{ .Site.Params.footer_one_title | default "Links" }}</h5>
         <ul class="list-unstyled">
-          <li><a href="/wiki/index.php/OpenEMR_Features">Features</a></li>
-          <li><a href="/demo">Demo</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Downloads">Download</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Modules">Modules</a></li>
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/wiki">Docs</a></li>
-          <li><a href="https://community.open-emr.org/">Forum</a></li>
-          <li><a href="/chat">Chat</a></li>
-          <li><a href="/donate">Donate</a></li>
-          <li><a href="/support">Support</a></li>
+          {{ range .Site.Menus.footer_one.ByWeight }}
+            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+          {{ end }}
         </ul>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
-        <h5 class="title nowiki">Help & Support Links</h5>
+        <h5 class="title nowiki">{{ .Site.Params.footer_two_title | default "Links" }}</h5>
         <ul class="list-unstyled">
-          <li><a href="/wiki/index.php/FAQ">FAQs</a></li>
-          <li><a href="https://community.open-emr.org/">Forum</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Wiki_Home_Page#User_Manuals">User Manuals</a></li>
-          <li><a href="/support">Support Guide</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Professional_Support">Professional Support</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Wiki_Home_Page#ONC_Ambulatory_EHR_Certification">Certification</a></li>
-          <li><a href="/wiki/index.php/OpenEMR_Acknowledgments">Acknowledgements</a></li>
+          {{ range .Site.Menus.footer_two.ByWeight }}
+            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+          {{ end }}
         </ul>
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
-        <!-- TODO: replace `&nbsp;` nesting solution with something more elegant -->
-        <!-- TODO: map inactive roots (e.x.: `Main Repository`) use a p tag -->
-        <h5 class="title nowiki">Developer Links</h5>
+        <h5 class="title nowiki">{{ .Site.Params.footer_three_title | default "Links" }}</h5>
         <ul class="list-unstyled">
-          <li>
-            <a href="/wiki/index.php/OpenEMR_Wiki_Home_Page#Developer_Manuals">
-              <i class="fa fa-book fa-fw fa-lg"></i>&nbsp;Developer Manuals
-            </a>
-          </li>
-          <li>
-            <a href="http://github.com/openemr/openemr/issues">
-              <i class="fa fa-bug fa-fw fa-lg"></i>&nbsp;Issues
-            </a>
-          </li>
-          <li>
-            <a href="http://github.com/openemr/openemr">
-              <i class="fa fa-github fa-fw fa-lg"></i>&nbsp;Github
-            </a>
-          </li>
+          {{ range .Site.Menus.footer_three.ByWeight }}
+            <li><a href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a></li>
+          {{ end }}
       </ul>
     </div>
   </div>

--- a/themes/openemr/layouts/partials/footer.html
+++ b/themes/openemr/layouts/partials/footer.html
@@ -9,15 +9,15 @@
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_one_title | default "Links" }}</h5>
-        {{ partial "menu.html" (dict "menuID" "footer_one" "page" . "listClass" "list-unstyled") }}
+        {{ partial "menu.html" (dict "menuID" "footer_one" "page" . "ulClass" "list-unstyled") }}
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_two_title | default "Links" }}</h5>
-        {{ partial "menu.html" (dict "menuID" "footer_two" "page" . "listClass" "list-unstyled") }}
+        {{ partial "menu.html" (dict "menuID" "footer_two" "page" . "ulClass" "list-unstyled") }}
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_three_title | default "Links" }}</h5>
-        {{ partial "menu.html" (dict "menuID" "footer_three" "page" . "listClass" "list-unstyled") }}
+        {{ partial "menu.html" (dict "menuID" "footer_three" "page" . "ulClass" "list-unstyled") }}
       </ul>
     </div>
   </div>

--- a/themes/openemr/layouts/partials/footer.html
+++ b/themes/openemr/layouts/partials/footer.html
@@ -9,26 +9,15 @@
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_one_title | default "Links" }}</h5>
-        <ul class="list-unstyled">
-          {{ range .Site.Menus.footer_one.ByWeight }}
-            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
-          {{ end }}
-        </ul>
+        {{ partial "menu.html" (dict "menuID" "footer_one" "page" . "listClass" "list-unstyled") }}
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_two_title | default "Links" }}</h5>
-        <ul class="list-unstyled">
-          {{ range .Site.Menus.footer_two.ByWeight }}
-            <li><a href="{{ .URL }}">{{ .Name }}</a></li>
-          {{ end }}
-        </ul>
+        {{ partial "menu.html" (dict "menuID" "footer_two" "page" . "listClass" "list-unstyled") }}
       </div>
       <div class="col-xs-12 col-sm-4 col-md-2">
         <h5 class="title nowiki">{{ .Site.Params.footer_three_title | default "Links" }}</h5>
-        <ul class="list-unstyled">
-          {{ range .Site.Menus.footer_three.ByWeight }}
-            <li><a href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a></li>
-          {{ end }}
+        {{ partial "menu.html" (dict "menuID" "footer_three" "page" . "listClass" "list-unstyled") }}
       </ul>
     </div>
   </div>

--- a/themes/openemr/layouts/partials/menu.html
+++ b/themes/openemr/layouts/partials/menu.html
@@ -1,10 +1,22 @@
+{{/*  
+ * Render a menu as a nested list.
+ * 
+ * This partial is intended to be used with the `menu` shortcode and is based
+  * on the `menu/walk.html` partial from the Hugo docs. It is extended to allow
+  * ulClass and navClass dicts to be passed in to allow for custom classes to be
+  * added to the ul and nav elements.
+  * 
+  * Usage example: {{ partial "menu.html" (dict "menuID" "main" "page" . "ulClass" "list-unstyled" "navClass" "navbar-nav") }}
+*/}}
 {{- $page := .page }}
 {{- $menuID := .menuID }}
-{{- $listClass := .listClass }}
+{{- $ulClass := .ulClass }}
+{{- $navClass := .navClass }}
+
 
 {{- with index site.Menus $menuID }}
-  <nav>
-    <ul {{ with $listClass }}class="{{ . }}"{{ end }}>
+  <nav{{ with $navClass }} class="{{ . }}"{{ end }}>
+    <ul {{ with $ulClass }}class="{{ . }}"{{ end }}>
       {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
     </ul>
   </nav>
@@ -32,7 +44,7 @@
             {{- printf " %s=%q" $k $v | safeHTMLAttr }}
           {{- end }}
         {{- end -}}
-      >{{ $name }}</a>
+      >{{ .Pre }}{{ $name }}{{ .Post }}</a>
       {{- with .Children }}
         <ul>
           {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}

--- a/themes/openemr/layouts/partials/menu.html
+++ b/themes/openemr/layouts/partials/menu.html
@@ -1,0 +1,44 @@
+{{- $page := .page }}
+{{- $menuID := .menuID }}
+{{- $listClass := .listClass }}
+
+{{- with index site.Menus $menuID }}
+  <nav>
+    <ul {{ with $listClass }}class="{{ . }}"{{ end }}>
+      {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+    </ul>
+  </nav>
+{{- end }}
+
+{{- define "partials/inline/menu/walk.html" }}
+  {{- $page := .page }}
+  {{- range .menuEntries }}
+    {{- $attrs := dict "href" .URL }}
+    {{- if $page.IsMenuCurrent .Menu . }}
+      {{- $attrs = merge $attrs (dict "class" "active" "aria-current" "page") }}
+    {{- else if $page.HasMenuCurrent .Menu .}}
+      {{- $attrs = merge $attrs (dict "class" "ancestor" "aria-current" "true") }}
+    {{- end }}
+    {{- $name := .Name }}
+    {{- with .Identifier }}
+      {{- with T . }}
+        {{- $name = . }}
+      {{- end }}
+    {{- end }}
+    <li>
+      <a
+        {{- range $k, $v := $attrs }}
+          {{- with $v }}
+            {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+          {{- end }}
+        {{- end -}}
+      >{{ $name }}</a>
+      {{- with .Children }}
+        <ul>
+          {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+        </ul>
+      {{- end }}
+    </li>
+  {{- end }}
+{{- end }}
+


### PR DESCRIPTION
Currently, the 3 footer menus are hardcoded into the theme. This PR abstracts the links into the config.yaml file and updates the layout to render the new menu arrays. Better separation of concern.

Draft for now until I can confirm the links are all working and I flesh out a fully supported link.

Resolves #41 