### PR TITLE
fix: Billboard abstraction

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,6 +6,7 @@ billboard:
     - url: donate
       title: Give Now
       content: Help support ongoing development of OpenEMR.
+      image: images/heart.svg
       classes:
         card: donation
     - url: demo

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,29 @@
+---
+title: The world's leading open-source<br>medical record software.
+subtitle: Donations fund ONC Certification, API, FHIR and more!
+billboard:
+  cards:
+    - url: donate
+      title: Give Now
+      content: Help support ongoing development of OpenEMR.
+      classes:
+        card: donation
+    - url: demo
+      title: Try Now
+      content: Login to a fully functioning demo of OpenEMR.
+      image: img/monitor.png
+    - url: support
+      title: Find Support
+      content: Find community-based or professional help.
+      image: img/info.png
+    - url: download
+      title: Download for Free
+      content: Get the latest version for Windows, macOS, or Linux.
+      image: img/download-arrow.png
+---
+
+Summary
+
+<!--more-->
+
+Content

--- a/static/images/heart.svg
+++ b/static/images/heart.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="91.44mm"
+   height="91.44mm"
+   clip-rule="evenodd"
+   fill-rule="evenodd"
+   image-rendering="optimizeQuality"
+   shape-rendering="geometricPrecision"
+   text-rendering="geometricPrecision"
+   version="1.1"
+   viewBox="0 0 9144 9144"
+   id="svg2"
+   sodipodi:docname="love-2195023.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="3.2899305"
+     inkscape:cx="172.8"
+     inkscape:cy="172.8"
+     inkscape:window-width="3440"
+     inkscape:window-height="1351"
+     inkscape:window-x="1911"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs2">
+    <style
+       type="text/css"
+       id="style1">.str0 {stroke:#FEFEFE;stroke-width:176.38} .str1 {stroke:#FEFEFE;stroke-width:176.38;stroke-linecap:round;stroke-linejoin:round} .fil1 {fill:none} .fil0 {fill:url(#a)}</style>
+    <linearGradient
+       id="a"
+       x1="8595.4"
+       x2="548.64"
+       y1="8595.4"
+       y2="548.63"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#48CFAE"
+         offset="0"
+         id="stop1" />
+      <stop
+         stop-color="#4FC0E8"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+  </defs>
+  <circle
+     class="fil1 str0"
+     cx="4572"
+     cy="4572"
+     id="circle2"
+     r="4356.6255" />
+  <path
+     class="fil1 str1"
+     d="m 4572.0001,3971.0863 c 0,-738.7948 598.8559,-1337.6508 1337.6507,-1337.6508 738.7948,0 1337.6506,598.856 1337.6506,1337.6508 0,1543.4431 -1973.5492,2776.1397 -2675.3013,3150.6819 C 3870.248,6747.226 1896.6987,5514.5294 1896.6987,3971.0863 c 0,-738.7948 598.856,-1337.6508 1337.6508,-1337.6508 738.7947,0 1337.6506,598.856 1337.6506,1337.6508 z"
+     id="path2" />
+</svg>

--- a/themes/openemr/assets/scss/_gt.scss
+++ b/themes/openemr/assets/scss/_gt.scss
@@ -18,21 +18,4 @@
 
     background-color: #00509D;
     background-color: hsl(217, 100, 21);
-
-    .donation {
-        background-color: hsl(76, 91, 38) !important;
-        @include transition(0.25s);
-
-        &:hover {
-            transform: scale(1.015);
-            background-color: hsl(76, 91, 35) !important;
-        }
-
-        a {
-            color: $gray-900;
-            &:hover {
-                text-decoration: none !important;
-            }
-        }
-    }
 }

--- a/themes/openemr/assets/scss/_jumbotron.scss
+++ b/themes/openemr/assets/scss/_jumbotron.scss
@@ -1,3 +1,14 @@
+@keyframes introduce_text {
+  0% { opacity: 0; transform: translateY(25px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+.introduce_text {
+  animation-name: introduce_text;
+  animation-duration: 0.55s;
+  animation-iteration-count: 1;
+}
+
 .billboard {
     @extend .container-fluid;
 
@@ -14,7 +25,7 @@
     }
 
     @include media-breakpoint-up(lg) {
-        min-height: 85vh;
+        // min-height: 85vh;
     }
 
     background-color: color("primary");
@@ -61,21 +72,11 @@
                 .card {
                     @extend .text-white;
                     @extend .text-start;
-                    @extend .bg-primary;
                     @extend .mb-2;
-                    background-color: #335489 !important;
-                    transition: background-color 0.25s;
+                    background-color: transparent;
 
                     h4 {
                         margin-bottom: 0;
-                    }
-
-                    &.donation {
-                        background-color: rgba(255, 26, 47, 0.8) !important;
-
-                        &:hover {
-                            background-color: rgb(255, 26, 46) !important;
-                        }
                     }
 
                     &:hover {
@@ -165,14 +166,6 @@
 
                 h4 {
                     margin-bottom: 0;
-                }
-
-                &.donation {
-                    background-color: rgba(255, 26, 47, 0.8) !important;
-
-                    &:hover {
-                        background-color: rgb(255, 26, 46) !important;
-                    }
                 }
 
                 &:hover {

--- a/themes/openemr/assets/scss/_nav.scss
+++ b/themes/openemr/assets/scss/_nav.scss
@@ -1,26 +1,10 @@
-.main-header.home {
-  @extend .armed-state;
-}
-
-.default-state {
-  background-color: rgba(map-get($theme-colors, "primary"), 0.90) !important;
-  @include media-breakpoint-down(md) {
-    background-color: map-get($theme-colors, "primary") !important;
-  }
-}
-
-.armed-state {
-  background-color: transparent;
-  @include media-breakpoint-down(md) {
-    background-color: map-get($theme-colors, "primary") !important;
-  }
-}
-
 .main-header {
     @extend .navbar;
     @extend .navbar-expand-lg;
     @extend .navbar-dark;
     @extend .fixed-top; // @extend .bg-primary;
+    
+    background-color: map-get($theme-colors, "primary");
     
     margin-top: 0 !important;
 

--- a/themes/openemr/assets/scss/_variables.scss
+++ b/themes/openemr/assets/scss/_variables.scss
@@ -108,7 +108,7 @@ $colors: (
 );
 
 $theme-colors: (
-  primary: $blue,
+  primary: hsl(217, 100, 21),
   secondary: $gray-600,
   success: $green,
   info: $cyan,

--- a/themes/openemr/layouts/index.html.html
+++ b/themes/openemr/layouts/index.html.html
@@ -1,62 +1,6 @@
-{{ define "main" }}
-<section class="billboard billboard__home billboard__home--giving-tuesday">
-    <div class="row">
-        <div class="content">
-            <div class="row">
-                <div class="col-sm-12">
-                    <h2 class="display-1 mb-4">Support OpenEMR, Give Today.</h2>
-                </div>
-                <div class="col-sm-12 col-lg-7">
-                    <p class="h4 font-weight-light pt-3 mb-5">
-                        Donations fund ONC Certification, API, FHIR and more!
-                    </p>
-                    <div class="card donation">
-                        <a href="{{ .Site.BaseURL }}donate/">
-                            <div class="card-body">
-                                <i class="text-white fa fa-heart fa-4x float-left me-4"></i>
-                                <h4 class="card-title">Give Now</h4>
-                                <div class="card-body">Help support future development of OpenEMR</div>
-                            </div>
-                        </a>
-                    </div> <!-- end .card -->
-                    <div class="pt-2 mb-4 ms-2 mt-4"><a href="https://open-emr.org/wiki/index.php/Professional_Support" class="btn btn-primary btn-lg font-weight-bold"><i class="fa fa-history"></i> Click here to find Professional Support</a></div>
-                    <div class="pt-2 mb-4 ms-2 mt-4"><a href="{{ .Site.BaseURL }}blog/buy-a-piece-of-openemr-history" class="btn btn-primary font-weight-bold"><i class="fa fa-history"></i> Click here to have fun donating to OpenEMR by purchasing a piece of OpenEMR History!</a></div>
-                </div>
-                <div class="target_nav col-sm-12 col-md-5 col-lg-5 pb-3 card-holders">
-                    <div class="card mb-1 d-none d-xl-flex">
-                        <a href="{{ .Site.Params.demoUrl }}">
-                            <div class="card-body">
-                                <img class="img-fluid float-left me-4" src="{{ .Site.BaseURL }}img/monitor.png" alt="Card image cap" height="64" width="64">
-                                <h4 class="card-title">Try Now</h4>
-                                <p class="card-text">Login to a fully functioning demo of OpenEMR</p>
-                            </div>
-                        </a>
-                    </div>  <!-- end card -->
-                    <div class="card mb-1">
-                        <a href="{{ "support" | absURL }}">
-                            <div class="card-body">
-                                <img class="img-fluid float-left me-4" src="{{ .Site.BaseURL }}img/info.png" alt="Card image cap" height="64" width="64">
-                                <h4 class="card-title">Find Support</h4>
-                                <p class="card-text">Free, community-driven support to assist you</p>
-                            </div>
-                        </a>
-                    </div> <!-- end .card -->
-                    <div class="card mb-1 d-none d-xl-flex">
-                        <a href="{{ .Site.Params.downloadUrl }}">
-                            <div class="card-body">
-                                <img class="img-fluid float-left me-4" src="{{ .Site.BaseURL }}img/download-arrow.png" alt="Card image cap" height="64" width="64">
-                                <h4 class="card-title">Download for Free</h4>
-                                <p class="card-text">Get the latest version for Windows, macOS, or Linux</p>
-                            </div>
-                        </a>
-                    </div> <!-- end .card -->
-                </div>  <!-- end .target_nav -->
-            </div>
-        </div>
-    </div>
-</section>
-
+{{- define "main" -}}
 {{- $homepages := (.Site.GetPage "homepage").Pages -}}
+{{- partial "homepage/billboard" . -}}
 
 {{/*  Render all featured pages sorted by weight  */}}
 {{- range where $homepages.ByWeight "Params.featured" true -}}

--- a/themes/openemr/layouts/partials/homepage/billboard-card.html
+++ b/themes/openemr/layouts/partials/homepage/billboard-card.html
@@ -1,0 +1,13 @@
+<div class="target_nav col-sm-12 col-md-6 col-lg-3 pb-3 card-holders">
+  <div class="card {{ .classes.card }}">
+    <a href="{{ .url }}">
+      <span class="card-body d-flex flex-column">
+        {{ with .image }}<img src="{{ . }}" width="64" class="mx-auto" alt="">{{ end }}
+        <div>
+          <h4>{{ .title }}</h4>
+          <span>{{ .content }}</span>
+        </div>
+      </span>
+    </a>
+  </div>
+</div>  <!-- end .target_nav -->

--- a/themes/openemr/layouts/partials/homepage/billboard-card.html
+++ b/themes/openemr/layouts/partials/homepage/billboard-card.html
@@ -1,7 +1,7 @@
-<div class="target_nav col-sm-12 col-md-6 col-lg-3 pb-3 card-holders">
-  <div class="card {{ .classes.card }}">
+<div class="target_nav col pb-3 card-holders">
+  <div class="card h-100 {{ .classes.card }}">
     <a href="{{ .url }}">
-      <span class="card-body d-flex flex-column">
+      <span class="card-body text-center d-flex flex-column">
         {{ with .image }}<img src="{{ . }}" width="64" class="mx-auto" alt="">{{ end }}
         <div>
           <h4>{{ .title }}</h4>

--- a/themes/openemr/layouts/partials/homepage/billboard.html
+++ b/themes/openemr/layouts/partials/homepage/billboard.html
@@ -2,12 +2,12 @@
   <div class="row">
     <div class="content">
       <div class="row">
-        <div class="col-sm-12 col-lg-12 pb-5">
-          <h1 class="display-4 text-white text-center mb-4">{{- .Title | safeHTML -}}</h1>
-          {{- with .Params.subtitle -}}<p class="h3 text-center pt-3 mb-5">{{- . -}}</p>{{- end -}}
+        <div class="col-sm-12 col-lg-12">
+          <h1 class="display-4 text-white text-center introduce_text">{{- .Title | safeHTML -}}</h1>
+          {{- with .Params.subtitle -}}<p class="h3 text-center pt-3 mb-2">{{- . -}}</p>{{- end -}}
         </div>
       </div>
-      <div class="row">
+      <div class="row mt-3 mb-3">
       {{- range .Params.billboard.cards -}}
         {{- partial "homepage/billboard-card" . -}}
       {{- end -}}

--- a/themes/openemr/layouts/partials/homepage/billboard.html
+++ b/themes/openemr/layouts/partials/homepage/billboard.html
@@ -1,0 +1,17 @@
+<section class="billboard billboard__home billboard__home--giving-tuesday">
+  <div class="row">
+    <div class="content">
+      <div class="row">
+        <div class="col-sm-12 col-lg-12 pb-5">
+          <h1 class="display-4 text-white text-center mb-4">{{- .Title | safeHTML -}}</h1>
+          {{- with .Params.subtitle -}}<p class="h3 text-center pt-3 mb-5">{{- . -}}</p>{{- end -}}
+        </div>
+      </div>
+      <div class="row">
+      {{- range .Params.billboard.cards -}}
+        {{- partial "homepage/billboard-card" . -}}
+      {{- end -}}
+      </div>
+    </div>
+  </div>
+</section>

--- a/themes/openemr/static/app.js
+++ b/themes/openemr/static/app.js
@@ -4,21 +4,4 @@
 
 $(document).ready(function(){
   $('.parallax').parallax();
-  var nav = document.getElementById('main-navigation');
-  if (nav.classList.contains('home') == true) {
-    nav.classList.remove('default-state');
-  }
-});
-
-window.addEventListener('scroll', function (e) {
-  var nav = document.getElementById("main-navigation");
-  if (nav.classList.contains("home") == true) {
-    if (document.documentElement.scrollTop || document.body.scrollTop > window.innerHeight) {
-      nav.classList.add('default-state');
-      nav.classList.remove('armed-state');
-    } else {
-      nav.classList.add('armed-state');
-      nav.classList.remove('default-state');
-    }
-  }
 });


### PR DESCRIPTION
Abstract the homepage billboard away from the theme. `content/_index.md` now contains the data required to render the various components.

I made more design changes to the billboard than any other part of the homepage. Here's an example of what the page will look like:

![image](https://github.com/openemr/website-openemr/assets/1381170/995002b7-2e87-43ea-8f2b-02cb3d514a7f)
