### PR TITLE
Fix: broken Footer link

### DIFF
--- a/themes/openemr/layouts/partials/menu.html
+++ b/themes/openemr/layouts/partials/menu.html
@@ -25,7 +25,7 @@
 {{- define "partials/inline/menu/walk.html" }}
   {{- $page := .page }}
   {{- range .menuEntries }}
-    {{- $attrs := dict "href" .URL }}
+    {{- $attrs := dict "href" (absURL .URL) }}
     {{- if $page.IsMenuCurrent .Menu . }}
       {{- $attrs = merge $attrs (dict "class" "active" "aria-current" "page") }}
     {{- else if $page.HasMenuCurrent .Menu .}}


### PR DESCRIPTION

This pull request resolves an issue where footer links were using relative paths, causing incorrect URL generation on subsequent clicks. This was most noticeable when navigating to the "modules" page from the footer multiple times, which could result in duplicated path segments in the URL.

⚙️ Changes
Modified themes/openemr/layouts/partials/menu.html to use the absURL function, ensuring all footer menu links are absolute URLs.

-- suggestion : Correct typo in the `dev` script in `package.json` from `--baseUrl` to `--baseURL`, if the Hugo failed to build 

🧪 How to Test

- Run the website locally using npm run dev.
- Navigate to any page.
- Scroll to the footer and click on a link (e.g., "modules").
- From the resulting page, scroll to the footer and click the same link again.
- Verify that the URL is correct and does not have duplicated path segments.

Dev Tested Video 
![openemer-devtested](https://github.com/user-attachments/assets/783fc55b-dd97-42eb-aa3c-51a8099ee2cd)
