### PR TITLE
prep robots.txt for final form (await setting of robot.txt in main server before bringing this in)

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,8 +1,4 @@
+# Disallow all crawling in github pages
+# Official server has its own robots.txt
 User-agent: *
-Allow: /
-Disallow: /index.php?
-Disallow: /index.php/Help:
-Disallow: /index.php/MediaWiki:
-Disallow: /index.php/Special:
-Disallow: /index.php/Template:
-Disallow: /skins/
+Disallow: /


### PR DESCRIPTION
prep robots.txt for final form (await setting of robot.txt in main server before bringing this in)

Not bringing this in until have robots.txt set up on the main server

Then the github pages direct website link will not get crawled by search engines and the main server link will.