### PR TITLE
ci(actionlint): lint GitHub Actions workflows on every change

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,31 +5,21 @@ on:
     branches:
       - master
     paths:
-      - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/workflows/**'
   pull_request:
+    branches:
+      - master
     paths:
-      - '.github/workflows/**'
       - '.github/actions/**'
-
-permissions:
-  contents: read
-  pull-requests: read
-
-concurrency:
-  group: actionlint-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+      - '.github/workflows/**'
 
 jobs:
   actionlint:
-    name: actionlint (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-24.04]
+    name: actionlint
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: reviewdog/action-actionlint@v1
         with:
           fail_level: error

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: actionlint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  actionlint:
+    name: actionlint (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error


### PR DESCRIPTION
## Summary

Adds a `reviewdog/action-actionlint@v1` job that runs on push to `master` and on every PR touching `.github/workflows/**` or `.github/actions/**`. Fails on `error`-level findings so workflow regressions surface in PR review rather than at runtime.

This is repo hygiene — useful for the existing `deploy.yml` and any future workflow.

## Background

Extracted from #82 (release-automation) so it can land independently. The release-automation slice will rebase cleanly on top of this once it merges.

## Test plan

- [ ] Watch this PR's own check: the new `actionlint` job runs against `.github/workflows/actionlint.yml` itself and `.github/workflows/deploy.yml` and reports clean.
- [ ] Touch a workflow in a future PR and confirm the job runs there too.