### PR TITLE
ci(dependabot): configure github-actions and npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+
+  # npm - root
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+      include: "scope"
+
+  # npm - themes/openemr
+  - package-ecosystem: "npm"
+    directory: "/themes/openemr"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+      include: "scope"


### PR DESCRIPTION
## Summary

Adds a Dependabot config covering the github-actions ecosystem and the two npm package manifests (root and `themes/openemr`). No Dependabot config existed before.

Schedule is weekly across all three ecosystems, and each ecosystem has a `commit-message` block so generated PRs match the repo's conventional-commit style (`ci(deps)`, `chore(deps)`, `chore(dev-deps)`) instead of producing default `Bump foo from 1.0 to 1.1` titles.

## Background

This is repo hygiene — useful for keeping the existing `deploy.yml` workflow's actions current and for tracking npm updates against the Hugo theme dependencies.

Split from #84 so it can land independently.

## Test plan

- [ ] Confirm Dependabot picks up the config and opens PRs against the configured ecosystems on its next schedule.