### PR TITLE
ci(deploy): override baseURL for Pages staging build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,3 +1,8 @@
+# Deploys the site to GitHub Pages staging at
+# https://openemr.github.io/website-openemr/ on every push to master.
+# Production (https://www.open-emr.org/) is not deployed by this
+# workflow — see openemr/website-openemr#92 for the planned prod
+# deploy.
 name: Deploy to GitHub Pages
 
 on:
@@ -10,13 +15,18 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize Pages deploys: only one in-flight at a time, but don't cancel
+# a running deploy if a new push arrives — let it finish before the next
+# starts. Matches GitHub's recommended Pages workflow template.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: true  # if theme is a submodule
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -33,8 +43,15 @@ jobs:
         run: npm ci
         working-directory: ./themes/openemr
 
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      # actions/configure-pages emits base_url without a trailing slash
+      # (e.g. https://openemr.github.io/website-openemr). Hugo expects a
+      # trailing slash on baseURL, so append one explicitly.
       - name: Build
-        run: hugo --minify
+        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary

The GitHub Pages staging site at https://openemr.github.io/website-openemr/ renders unstyled in Firefox. This PR fixes that by overriding Hugo's `baseURL` at deploy time so the staging build emits same-origin asset URLs. Also folds in a few smaller workflow cleanups in the same area.

## Diagnosis

`config.yaml` sets `baseURL: https://www.open-emr.org/` so that production builds emit absolute URLs to the live domain. The same build is currently also pushed to GitHub Pages staging, so the page at `openemr.github.io/website-openemr/` references stylesheets at `www.open-emr.org/style.min.<hash>.css` — cross-origin to the page itself.

The theme emits stylesheet `<link>` tags with an `integrity` attribute but no `crossorigin` attribute:

```html
<link rel=stylesheet href=https://www.open-emr.org/style.min.<hash>.css
      integrity="sha256-...">
```

Per the [SRI spec](https://www.w3.org/TR/SRI/), when `integrity` is present and the request is not in `cors` mode, the response is opaque and the integrity check fails by definition — even when the bytes match. Firefox enforces this strictly, which is why staging renders unstyled. The bytes do match (verified by hashing the served CSS), so a stricter browser is doing the right thing here; the markup is broken.

The `<script>` tags in the same `<head>` *do* have `crossorigin=anonymous`, so JS still loads. The theme is internally inconsistent.

## Fix

Add `actions/configure-pages` to the deploy workflow and pass its `base_url` output to `hugo --baseURL`. This makes the staging build emit asset URLs at `openemr.github.io/website-openemr/...` — same-origin to the page — so SRI works without needing a `crossorigin` attribute.

Production is not affected: it's deployed by a separate manual process (`web_openemr_update` in `openemr/website-devops`) that doesn't go through this workflow.

## Other changes in this PR

- Rename `.github/workflows/deploy.yml` → `deploy-pages.yml` and add a top-of-file comment so the staging-only scope is obvious from the file name. The planned production deploy is tracked in #92.
- Add a `concurrency: pages` group with `cancel-in-progress: false` so two pushes in quick succession serialize their deploys instead of racing. Matches GitHub's recommended Pages workflow template.
- Drop `submodules: true` from the checkout step — there is no `.gitmodules` and `themes/openemr/` is committed as a regular tree, so the flag was a no-op.

## Follow-up (not in this PR)

Issue #94 tracks a content-cleanup pass to convert hard-coded absolute `https://www.open-emr.org/<local-path>` links in markdown content to relative paths, so they don't jump from staging back to production when clicked.

## Test plan

- [ ] After merge, load https://openemr.github.io/website-openemr/ in Firefox and confirm the page renders with styles applied.
- [ ] Check browser devtools → network: stylesheet request goes to `openemr.github.io/website-openemr/...`, not `www.open-emr.org/...`.
- [ ] Check the same in Chrome and Safari (was probably already working there, but no regression expected).
- [ ] The two pre-existing root-path icon 404s (`/favicon-16x16.png`, `/apple-touch-icon.png`) should be resolved as a side effect of the same baseURL change.
