### PR TITLE
fix(theme): add crossorigin=anonymous to fingerprinted CSS link

### DIFF
--- a/themes/openemr/layouts/partials/header.html
+++ b/themes/openemr/layouts/partials/header.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true) }}
 {{ $style := resources.Get "scss/style.scss" | toCSS $options | minify | fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 {{ with .OutputFormats.Get "RSS" }}
 <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml">
 {{ end }}


### PR DESCRIPTION
## Summary

The Hugo-built `<link>` for `style.scss` carries an `integrity=` attribute but no `crossorigin=`. Per the [SRI spec](https://www.w3.org/TR/SRI/), integrity checks require the request be in CORS mode whenever the resource is not same-origin to the page; without `crossorigin=`, a cross-origin response is opaque and the integrity check fails by definition. Firefox enforces this strictly and refuses to apply the stylesheet.

## Why this is breaking prod now

Since #93 the staging build emits its CSS URL at `https://openemr.github.io/website-openemr/style.min.<hash>.css`. That works on staging itself (same-origin), but the same HTML bytes are also mirrored verbatim to `https://www.open-emr.org/`. On the prod domain the link becomes cross-origin to the page, SRI fails, and pages render unstyled until the upstream cache expires. `/demo/` (rebuilt yesterday) is currently affected; older cached pages still serve the pre-#93 markup so the breakage is patchy.

The script tags in the same `<head>` already carry `crossorigin=anonymous` for their CDN sources — only the inline-built CSS link was missing it. github.io serves the CSS with `access-control-allow-origin: *`, so adding the attribute is sufficient for SRI to validate from any origin.

## Note on PR #93's premise

#93's description claimed "Production is not affected: it's deployed by a separate manual process … that doesn't go through this workflow." That assumption turned out to be wrong — www.open-emr.org mirrors the github.io build automatically. This PR fixes the resulting SRI failure without unwinding #93. Worth a follow-up to update the deploy workflow header comment and revisit #92, but not blocking.

## Test plan

- [x] After merge + staging deploy, view the `<head>` of any page on https://openemr.github.io/website-openemr/ and confirm the CSS link has `crossorigin="anonymous"`.
- [ ] Once the mirror picks up the new HTML and Cloudflare's cache expires (or is purged), reload https://www.open-emr.org/demo/ in Firefox and confirm the page renders with styles applied.
- [ ] Browser devtools → no SRI error in console; CSS request shows CORS mode.