### PR TITLE
ci: drop single-entry runner matrix from workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -53,11 +53,8 @@ env:
 
 jobs:
   build:
-    name: hugo build (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        runner: [ubuntu-24.04]
+    name: hugo build
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -35,12 +35,8 @@ concurrency:
 
 jobs:
   probe:
-    name: probe (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-24.04]
+    name: probe
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Drops the useless single-entry `runner: [ubuntu-24.04]` matrix from two workflows that picked up the pattern. The matrix added no value (no second runner to vary on) and made the job name harder to read.

- `release-permissions-check.yml` — manual one-shot probe.
- `deploy-pages.yml` — same pattern, came in via #85.

Follow-up to #82.