### PR TITLE
fix(release-docs): widen vendored dispatch branch + tag patterns

### DIFF
--- a/tools/release-docs/contracts/dispatch.schema.json
+++ b/tools/release-docs/contracts/dispatch.schema.json
@@ -33,12 +33,14 @@
             }
         },
         "branch": {
+            "description": "Release branch name. Per #664 spec real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut.",
             "type": "string",
-            "pattern": "^rel-(\\d+)(\\d)0$"
+            "pattern": "^rel-[A-Za-z0-9]+$"
         },
         "tag": {
+            "description": "Release tag name. Per #664 spec real releases use v<MAJOR>_<MINOR>_<PATCH>. Test runs append -test.<shortSha> (7 hex chars) so a test merge does not collide with a real release tag.",
             "type": "string",
-            "pattern": "^v(\\d+)_(\\d+)_(\\d+)$"
+            "pattern": "^v\\d+_\\d+_\\d+(-test\\.[0-9a-f]{7})?$"
         },
         "version": {
             "type": "string",

--- a/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
+++ b/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-tag",
+    "repo": "openemr/openemr",
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "actor": "openemr-release-bot[bot]",
+    "dispatched_at": "2026-05-01T10:00:00Z",
+    "data": {
+        "tag": "v8_1_0-test.abcdef0",
+        "branch": "rel-test",
+        "version": "8.1.0"
+    }
+}


### PR DESCRIPTION
The conductor in `openemr/openemr` widened the dispatch payload `branch` pattern to `^rel-[A-Za-z0-9]+$` (openemr/openemr#12061) and the `tag` pattern to allow an optional `-test.{shortSha}` suffix (openemr/openemr#12063), so test runs against a sandbox branch like `rel-test` produce `v8_1_2-test.419858f` tags.

The vendored `dispatch.schema.json` here lagged the conductor: every `repository_dispatch` this session sent to `release-docs.yml` failed schema validation on `/data/branch` and `/data/tag` and the consumer never reached the docs-rendering steps.

Bringing the vendored schema in line; adds `valid-openemr-tag-test.json` covering the new shape. Companion canonical-source update is in openemr/openemr-devops#700.

Refs openemr/openemr-devops#664.