### PR TITLE
fix(release-docs): pass App token as GITHUB_TOKEN to gen-release-notes

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Generate release notes
         if: ${{ steps.payload.outputs.prev_release != '' }}
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           PREV: ${{ steps.payload.outputs.prev_release }}
           VERSION: ${{ steps.payload.outputs.version }}
         run: task gen-release-notes REPO_PATH="$OPENEMR_CHECKOUT" PREV_VERSION="$PREV" VERSION="$VERSION"


### PR DESCRIPTION
The `Generate release notes` step in `release-docs.yml` mints an App token and exposes it as `GH_TOKEN`, but `bin/gen-release-notes.php` reads `--token` or `GITHUB_TOKEN`. The step fails immediately with `GitHub token required (--token or GITHUB_TOKEN env)`.

Rename the env var so the script picks up the token.

Closes #101