### PR TITLE
fix(release-docs): widen manifest branch regex to match canonical contract

### DIFF
--- a/data/releases.schema.json
+++ b/data/releases.schema.json
@@ -13,8 +13,9 @@
             "properties": {
                 "status": { "enum": ["DRAFT", "FINAL"] },
                 "branch": {
+                    "description": "Release branch name. Real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut. Matches the canonical dispatch.schema.json branch pattern in openemr/openemr-devops.",
                     "type": "string",
-                    "pattern": "^rel-(\\d+)(\\d)0$"
+                    "pattern": "^rel-[A-Za-z0-9]+$"
                 },
                 "sha": {
                     "type": "string",


### PR DESCRIPTION
## Summary

The canonical `dispatch.schema.json` in `openemr-devops` widened the release branch pattern from `^rel-(\d+)(\d)0$` to `^rel-[A-Za-z0-9]+$` so test branches like `rel-test` can drive the workflow end-to-end. The manifest schema in this repo (`data/releases.schema.json`) independently encoded the narrow pattern, so test-mode payloads from `rel-test` still failed manifest validation after gen-release-notes started succeeding (#102).

Widen the pattern here to match. Real-release names continue to match.

Surfaced today on the first end-to-end test cycle that got past the gen-release-notes step:

```
manifest failed schema validation: {
    "/8.1.4/branch": [
        "The string should match pattern: ^rel-(\\d+)(\\d)0$"
    ]
}
```

## Test plan

- [ ] Re-run the conductor in test mode (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.5 -f branch=rel-test -f test=true`) and merge the resulting prep PR.
- [ ] Confirm the `release-docs` workflow gets past `Update releases manifest` on the resulting `openemr-rel-cut` / `openemr-tag` dispatches.

Refs openemr/openemr-devops#664.