### PR TITLE
fix(release-docs): authenticate git push as the release App, not github-actions[bot]

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -83,6 +83,14 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
+        with:
+          # Don't persist GITHUB_TOKEN as a git http.extraheader. That
+          # header takes precedence over credentials we later embed in
+          # the remote URL, so the workflow's `git push` would
+          # authenticate as github-actions[bot] (limited to this
+          # workflow's `contents: read` scope) instead of the App token
+          # minted below — and 403.
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -6,8 +6,16 @@ name: release-permissions-check
 #
 # Three things are probed:
 #
-# 1. `contents: write` on this repo — verified by creating and then
-#    deleting an empty `release-perms-probe/<run-id>` branch.
+# 1. `contents: write` on this repo — verified by checking out the
+#    repo without persisted credentials, embedding the App token in
+#    the remote URL, and force-pushing (then deleting) an empty
+#    commit on `release-perms-probe/<run-id>`. This deliberately
+#    mirrors release-docs.yml's `git push` path. An earlier version
+#    of this probe used the REST refs API, which doesn't go through
+#    git's http.extraheader layer and so couldn't catch the
+#    extraheader-vs-URL-credentials precedence bug that made
+#    release-docs.yml 403 on push despite the App holding
+#    `contents: write`.
 # 2. `pull-requests: write` on this repo — verified by listing PRs.
 # 3. Cross-repo `repository_dispatch` to website-openemr-files using
 #    the `release-permissions-probe` event type. The receiving repo's
@@ -47,18 +55,29 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }},website-openemr-files
 
-      - name: Probe contents:write — create and delete a probe branch
+      # Mirror release-docs.yml's checkout (no persisted credentials)
+      # so the probe exercises the same auth path as the real workflow.
+      - name: Checkout for git-push probe
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Probe contents:write — push and delete a probe branch
         id: contents
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           branch="release-perms-probe/${GITHUB_RUN_ID}"
-          base_sha=$(gh api "repos/${REPO}/git/ref/heads/$(gh api "repos/${REPO}" --jq '.default_branch')" --jq '.object.sha')
-          gh api -X POST "repos/${REPO}/git/refs" -f "ref=refs/heads/${branch}" -f "sha=${base_sha}" >/dev/null
-          gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}" >/dev/null
+          git config user.name 'openemr-release-bot[bot]'
+          git config user.email 'openemr-release-bot[bot]@users.noreply.github.com'
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -B "$branch"
+          git commit --allow-empty -m "release-permissions-check probe ${GITHUB_RUN_ID}"
+          git push --force-with-lease origin "HEAD:${branch}"
+          git push origin --delete "$branch"
           echo 'ok=true' >> "$GITHUB_OUTPUT"
 
       - name: Probe pull-requests:write — list open PRs


### PR DESCRIPTION
## Summary

The `Commit and force-push docs branch` step in `release-docs.yml` was 403ing despite the release App holding `contents: write` on this repo. Root cause: `actions/checkout@v4` writes `http.https://github.com/.extraheader` into `.git/config` carrying the workflow's default `GITHUB_TOKEN`. That header is sent on every HTTPS git request and **takes precedence** over the App-token credentials we embed in the remote URL — so the push authenticated as `github-actions[bot]` (limited to this workflow's `contents: read` scope) and was denied:

```
remote: Permission to openemr/website-openemr.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

Fix: pass `persist-credentials: false` to the website-openemr checkout so the App token in the remote URL is the only auth git sees.

## Probe upgrade

`release-permissions-check.yml` previously verified `contents: write` by creating/deleting a ref via the REST API. That call carries the App token directly in `Authorization: Bearer` and never touches git's `http.extraheader` layer — so it passed cleanly while the real workflow 403'd.

This PR rewrites the probe to use the same `git push` path the workflow uses (checkout with `persist-credentials: false`, embed token in remote URL, force-push and delete a `release-perms-probe/<run-id>` branch). Future drift between the App's actual write capability and the workflow's effective auth identity gets caught here instead of mid-release.

## Test plan

- [ ] After merge, run `release-permissions-check` (workflow_dispatch) and confirm all three probes still pass.
- [ ] Re-run the conductor in test mode (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.6 -f branch=rel-test -f test=true`) and merge the resulting prep PR.
- [ ] Confirm `release-docs` gets past `Commit and force-push docs branch` on the resulting `openemr-rel-cut` / `openemr-tag` dispatches.

Refs openemr/openemr-devops#664.