### PR TITLE
fix(release-docs): fetch branch before --force-with-lease

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -183,6 +183,13 @@ tasks:
         git config user.email 'openemr-release-bot[bot]@users.noreply.github.com'
         git remote set-url origin \
           "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        # The first dispatch for a version creates release-docs/$VERSION;
+        # later dispatches in the same release (rel-update, openemr-tag)
+        # check out master and so have no local ref for this branch.
+        # Without this fetch, --force-with-lease sees an empty local
+        # baseline against a non-empty remote and rejects with
+        # "stale info". Ignore failure: branch may not exist yet.
+        git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
         git checkout -B "$BRANCH"
         git add -A
         if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary

The first dispatch for a version (typically `openemr-rel-cut`) creates `release-docs/$VERSION` on the remote. Later dispatches in the same release (`openemr-rel-update`, `openemr-tag`) check out master and have no local ref for the branch — so `--force-with-lease` compares an empty local baseline against a non-empty remote and rejects:

```
! [rejected]  HEAD -> release-docs/8.1.6 (stale info)
error: failed to push some refs
```

Fetch the branch (ignoring failure if it doesn't exist yet) so the lease check sees the actual remote state. Lease semantics are preserved: a real concurrent write between fetch and push will still be rejected.

Surfaced today on the first end-to-end run that reached the push step: `openemr-rel-cut` for 8.1.6 succeeded, then `openemr-tag` for the same version failed at push with `stale info`.

## Test plan

- [ ] After merge, fire another conductor cycle (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.7 -f branch=rel-test -f test=true`), merge the prep PR.
- [ ] Confirm both the `openemr-rel-cut` (or `openemr-rel-update`) and `openemr-tag` runs of `release-docs` complete successfully and produce / update the `release-docs/8.1.7` PR.

Refs openemr/openemr-devops#664.