### PR TITLE
fix(release-docs): preserve prior-dispatch artifacts, isolate test-mode, gitignore .openemr-src

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -134,6 +134,25 @@ jobs:
           task workflow:strip-sidecar
           task validate-dispatch PAYLOAD="$RUNNER_TEMP/payload.canonical.json"
 
+      # Conductor test-mode runs (openemr/openemr release-prep with test=true)
+      # dispatch from `rel-test`. Treating those as production would put
+      # fake versions in data/releases.json and open mergeable docs PRs that
+      # ship test artifacts. Instead, route test-mode pushes to a parallel
+      # `release-docs-test/<version>` branch and skip the manifest write.
+      # The end-to-end auth/lease/cumulative-checkout paths are still
+      # exercised; only the production-facing side effects are gated off.
+      - name: Detect test mode
+        id: mode
+        env:
+          BRANCH_FROM_PAYLOAD: ${{ steps.payload.outputs.branch }}
+        run: |
+          if [ "$BRANCH_FROM_PAYLOAD" = 'rel-test' ]; then
+            echo 'test=true' >> "$GITHUB_OUTPUT"
+            echo 'Test-mode dispatch — pushing to release-docs-test/* and skipping manifest write.'
+          else
+            echo 'test=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Sparse-checkout openemr/openemr at dispatched sha
         uses: actions/checkout@v4
         with:
@@ -174,6 +193,7 @@ jobs:
         run: task gen-upgrade-page VERSION="$VERSION" PREVIOUS_VERSION="$PREV"
 
       - name: Update releases manifest
+        if: ${{ steps.mode.outputs.test != 'true' }}
         env:
           PAYLOAD: ${{ steps.payload.outputs.file }}
         run: |
@@ -183,7 +203,7 @@ jobs:
       - name: Commit and force-push docs branch
         id: push
         env:
-          BRANCH: release-docs/${{ steps.payload.outputs.version }}
+          BRANCH: ${{ steps.mode.outputs.test == 'true' && format('release-docs-test/{0}', steps.payload.outputs.version) || format('release-docs/{0}', steps.payload.outputs.version) }}
           EVENT: ${{ steps.payload.outputs.event }}
           VERSION: ${{ steps.payload.outputs.version }}
           SHA: ${{ steps.payload.outputs.sha }}
@@ -193,7 +213,7 @@ jobs:
       - name: Open or update draft PR
         if: ${{ steps.push.outputs.pushed == 'true' }}
         env:
-          BRANCH: release-docs/${{ steps.payload.outputs.version }}
+          BRANCH: ${{ steps.mode.outputs.test == 'true' && format('release-docs-test/{0}', steps.payload.outputs.version) || format('release-docs/{0}', steps.payload.outputs.version) }}
           EVENT: ${{ steps.payload.outputs.event }}
           VERSION: ${{ steps.payload.outputs.version }}
           SHA: ${{ steps.payload.outputs.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ bh_unicode_properties.cache
 GitHub.sublime-settings
 
 # End of https://www.toptal.com/developers/gitignore/api/hugo,node,sublimetext
+
+# release-docs sparse checkout of openemr/openemr (input for generators)
+/.openemr-src

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -185,12 +185,17 @@ tasks:
           "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         # The first dispatch for a version creates release-docs/$VERSION;
         # later dispatches in the same release (rel-update, openemr-tag)
-        # check out master and so have no local ref for this branch.
-        # Without this fetch, --force-with-lease sees an empty local
-        # baseline against a non-empty remote and rejects with
-        # "stale info". Ignore failure: branch may not exist yet.
-        git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
-        git checkout -B "$BRANCH"
+        # check out master and have no local ref for the branch. We need
+        # to (a) build on top of any prior dispatch's artifacts so this
+        # commit doesn't clobber them, and (b) give --force-with-lease a
+        # current baseline so it doesn't reject with "stale info".
+        # Both come from fetching the branch and basing our work on it.
+        if git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
+          git checkout -B "$BRANCH" "origin/${BRANCH}"
+        else
+          # First dispatch for this version — branch doesn't exist yet.
+          git checkout -B "$BRANCH"
+        fi
         git add -A
         if git diff --cached --quiet; then
           echo 'no docs changes; skipping push'


### PR DESCRIPTION
## Summary

Three related issues surfaced on the first end-to-end run that reached the push step (8.1.7 test cycle, `openemr-rel-cut` followed by `openemr-tag` — see [PR #107](https://github.com/openemr/website-openemr/pull/107) for the bad output).

### 1. `openemr-tag` clobbered `openemr-rel-cut`'s output

`commit-push` fetched the branch but then ran `git checkout -B "$BRANCH"` from current HEAD (master), discarding the rel-cut commit. `--force-with-lease` then validated against the fetched ref and overwrote the branch with master+install-page only — losing acknowledgements, release-notes, and the upgrade page that rel-cut had generated.

Fix: base the working branch on `origin/$BRANCH` when it exists so each dispatch builds on top of the prior one. First dispatch for a version still falls back to master.

### 2. Test-mode dispatches contaminated production artifacts

Conductor `test=true` runs (which dispatch from `rel-test`) were treated as production: they wrote fake versions like 8.1.7 to `data/releases.json` and opened mergeable `release-docs/*` PRs.

Fix: detect test mode (`branch == rel-test`), route the push to a parallel `release-docs-test/<version>` namespace, and skip the manifest write. Auth, lease, and cumulative-checkout paths are still exercised end-to-end; only production-facing side effects are gated off.

### 3. `.openemr-src` was committed as a submodule gitlink

`git add -A` swept in the sparse-checkout dir, recording it as a gitlink (mode 160000):
```
+Subproject commit 3bedfff276fdfdfd50dde354923917c21ec26a22
```

Fix: gitignore `/.openemr-src`.

## Cleanup needed (separate, manual)

Existing `release-docs/8.1.{3..7}` test branches and PRs (including #107) predate this fix and contain bad data. They should be closed and the branches deleted.

## Test plan

- [ ] After merge, fire another conductor cycle (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.8 -f branch=rel-test -f test=true`), merge the prep PR.
- [ ] Confirm the dispatches push to `release-docs-test/8.1.8` (not `release-docs/8.1.8`).
- [ ] Confirm `data/releases.json` on master is unchanged.
- [ ] Confirm the resulting test branch carries acknowledgements + release-notes + upgrade + install (cumulative across rel-cut and tag dispatches), and does NOT carry `.openemr-src`.

Refs openemr/openemr-devops#664.