### PR TITLE
fix(release-docs): switch branch via update-ref/reset, not checkout

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -189,9 +189,20 @@ tasks:
         # to (a) build on top of any prior dispatch's artifacts so this
         # commit doesn't clobber them, and (b) give --force-with-lease a
         # current baseline so it doesn't reject with "stale info".
-        # Both come from fetching the branch and basing our work on it.
+        #
+        # We can't `git checkout -B "$BRANCH" origin/$BRANCH` because the
+        # generators (which ran earlier in the workflow) wrote
+        # content/<section>/<version>.md as untracked files in the
+        # working tree. Those paths are tracked on origin/$BRANCH from
+        # the prior dispatch, and a real checkout refuses to clobber
+        # untracked files. Instead, point HEAD at $BRANCH and reset the
+        # index to match origin/$BRANCH without touching the working
+        # tree — `git add -A` then sees the generators' files as
+        # modifications to the existing tracked content.
         if git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
-          git checkout -B "$BRANCH" "origin/${BRANCH}"
+          git update-ref "refs/heads/${BRANCH}" "refs/remotes/origin/${BRANCH}"
+          git symbolic-ref HEAD "refs/heads/${BRANCH}"
+          git reset --mixed
         else
           # First dispatch for this version — branch doesn't exist yet.
           git checkout -B "$BRANCH"


### PR DESCRIPTION
## Summary

The previous fix used `git checkout -B "$BRANCH" origin/$BRANCH` to build cumulatively on the prior dispatch. It failed on the second dispatch in a chain (`openemr-tag` after `openemr-rel-cut`):

```
error: The following untracked working tree files would be overwritten by checkout:
  content/installation/8.1.8.md
Please move or remove them before you switch branches.
```

Sequence: `actions/checkout` pulled master, the generators wrote `content/<section>/<version>.md` as untracked files, then `commit-push` tried to switch branches to one whose tip already tracks those paths. Git correctly refused to clobber the untracked files.

## Fix

Switch branches without touching the working tree:

```bash
git update-ref "refs/heads/${BRANCH}" "refs/remotes/origin/${BRANCH}"
git symbolic-ref HEAD "refs/heads/${BRANCH}"
git reset --mixed
```

After this, HEAD points to `$BRANCH`, the index reflects `origin/$BRANCH`'s tree, and the working tree (containing the just-generated files) is untouched. `git add -A` then sees the generators' output as modifications to the previously tracked content, and that becomes the new commit's payload.

Cumulative behavior preserved; `--force-with-lease` still gets a real baseline; no checkout-vs-untracked conflict.

## Test plan

- [ ] After merge, fire another conductor cycle (8.1.9), merge the prep PR.
- [ ] Confirm `release-docs-test/8.1.9` carries content from both rel-cut and tag dispatches.
- [ ] Confirm both dispatch runs complete without the "untracked working tree files" error.

Refs openemr/openemr-devops#664.