### PR TITLE
refactor(release-docs): decouple generator output from publish-target working tree

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -15,6 +15,12 @@ name: release-docs
 # step is a Taskfile target under tools/release-docs/Taskfile.yml so the
 # operations can be invoked locally for debugging the same way CI runs
 # them. See the `workflow:*` tasks there.
+#
+# The workspace checkout is the *build environment* only (Composer deps,
+# generator source). Generators write into $STAGING under $RUNNER_TEMP,
+# and a separate $PUBLISH clone is the actual force-push target. This
+# decoupling keeps the workspace's untracked generated files from
+# colliding with the publish branch's tracked content during checkout.
 
 on:
   repository_dispatch:
@@ -78,19 +84,28 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-24.04]
-    env:
-      OPENEMR_CHECKOUT: ${{ github.workspace }}/.openemr-src
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
         with:
-          # Don't persist GITHUB_TOKEN as a git http.extraheader. That
-          # header takes precedence over credentials we later embed in
-          # the remote URL, so the workflow's `git push` would
-          # authenticate as github-actions[bot] (limited to this
-          # workflow's `contents: read` scope) instead of the App token
-          # minted below — and 403.
+          # Defense in depth — we no longer push from this checkout, but
+          # leaving GITHUB_TOKEN persisted as an http.extraheader would
+          # still cause confusion if anything downstream did a git push
+          # from $GITHUB_WORKSPACE.
           persist-credentials: false
+
+      # runner.temp isn't available in job-level env, so resolve all
+      # working paths here and export them via GITHUB_ENV. All paths under
+      # $RUNNER_TEMP so the workspace checkout stays a clean build env —
+      # no untracked working-tree files for the generators to leak into
+      # git operations.
+      - name: Define working paths
+        run: |
+          {
+            printf 'OPENEMR_CHECKOUT=%s\n' "$RUNNER_TEMP/openemr-src"
+            printf 'STAGING=%s\n' "$RUNNER_TEMP/staging"
+            printf 'PUBLISH=%s\n' "$RUNNER_TEMP/publish"
+          } >> "$GITHUB_ENV"
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -139,8 +154,8 @@ jobs:
       # fake versions in data/releases.json and open mergeable docs PRs that
       # ship test artifacts. Instead, route test-mode pushes to a parallel
       # `release-docs-test/<version>` branch and skip the manifest write.
-      # The end-to-end auth/lease/cumulative-checkout paths are still
-      # exercised; only the production-facing side effects are gated off.
+      # Only the production-facing side effects are gated off; auth, lease,
+      # and cumulative-publish paths are still exercised end-to-end.
       - name: Detect test mode
         id: mode
         env:
@@ -158,19 +173,30 @@ jobs:
         with:
           repository: openemr/openemr
           ref: ${{ steps.payload.outputs.sha }}
-          path: .openemr-src
+          path: ${{ runner.temp }}/openemr-src
           fetch-depth: 0
           sparse-checkout: |
             .git
             version.php
             CHANGELOG.md
 
+      - name: Prepare staging + publish-target
+        env:
+          BRANCH: ${{ steps.mode.outputs.test == 'true' && format('release-docs-test/{0}', steps.payload.outputs.version) || format('release-docs/{0}', steps.payload.outputs.version) }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: task workflow:prepare-publish
+
       - name: Generate acknowledgements
         if: ${{ steps.payload.outputs.prev_release != '' }}
         env:
           PREV: ${{ steps.payload.outputs.prev_release }}
           VERSION: ${{ steps.payload.outputs.version }}
-        run: task gen-acknowledgements REPO_PATH="$OPENEMR_CHECKOUT" PREV_VERSION="$PREV" VERSION="$VERSION"
+        run: >-
+          task gen-acknowledgements
+          REPO_PATH="$OPENEMR_CHECKOUT"
+          PREV_VERSION="$PREV"
+          VERSION="$VERSION"
+          OUTPUT="$STAGING/content/acknowledgements/$VERSION.md"
 
       - name: Generate release notes
         if: ${{ steps.payload.outputs.prev_release != '' }}
@@ -178,19 +204,31 @@ jobs:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           PREV: ${{ steps.payload.outputs.prev_release }}
           VERSION: ${{ steps.payload.outputs.version }}
-        run: task gen-release-notes REPO_PATH="$OPENEMR_CHECKOUT" PREV_VERSION="$PREV" VERSION="$VERSION"
+        run: >-
+          task gen-release-notes
+          REPO_PATH="$OPENEMR_CHECKOUT"
+          PREV_VERSION="$PREV"
+          VERSION="$VERSION"
+          OUTPUT="$STAGING/content/release-notes/$VERSION.md"
 
       - name: Generate install page
         env:
           VERSION: ${{ steps.payload.outputs.version }}
-        run: task gen-install-page VERSION="$VERSION"
+        run: >-
+          task gen-install-page
+          VERSION="$VERSION"
+          OUTPUT="$STAGING/content/installation/$VERSION.md"
 
       - name: Generate upgrade page
         if: ${{ steps.payload.outputs.prev_release != '' }}
         env:
           PREV: ${{ steps.payload.outputs.prev_release }}
           VERSION: ${{ steps.payload.outputs.version }}
-        run: task gen-upgrade-page VERSION="$VERSION" PREVIOUS_VERSION="$PREV"
+        run: >-
+          task gen-upgrade-page
+          VERSION="$VERSION"
+          PREVIOUS_VERSION="$PREV"
+          OUTPUT="$STAGING/content/upgrade/$VERSION.md"
 
       - name: Update releases manifest
         if: ${{ steps.mode.outputs.test != 'true' }}
@@ -198,7 +236,9 @@ jobs:
           PAYLOAD: ${{ steps.payload.outputs.file }}
         run: |
           task workflow:strip-sidecar
-          task update-manifest PAYLOAD="$RUNNER_TEMP/payload.canonical.json"
+          task update-manifest \
+            PAYLOAD="$RUNNER_TEMP/payload.canonical.json" \
+            MANIFEST="$PUBLISH/data/releases.json"
 
       - name: Commit and force-push docs branch
         id: push
@@ -207,7 +247,6 @@ jobs:
           EVENT: ${{ steps.payload.outputs.event }}
           VERSION: ${{ steps.payload.outputs.version }}
           SHA: ${{ steps.payload.outputs.sha }}
-          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: task workflow:commit-push
 
       - name: Open or update draft PR

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -42,6 +42,7 @@ tasks:
     vars:
       OUTPUT: '{{.OUTPUT | default (printf "%s/content/acknowledgements/%s.md" .REPO_ROOT .VERSION)}}'
     cmds:
+      - mkdir -p "$(dirname '{{.OUTPUT}}')"
       - >-
         php bin/gen-acknowledgements.php
         --repo-path={{.REPO_PATH}}
@@ -59,6 +60,7 @@ tasks:
       REPO: '{{.REPO | default "openemr"}}'
       OUTPUT: '{{.OUTPUT | default (printf "%s/content/release-notes/%s.md" .REPO_ROOT .VERSION)}}'
     cmds:
+      - mkdir -p "$(dirname '{{.OUTPUT}}')"
       - >-
         php bin/gen-release-notes.php
         --owner={{.OWNER}}
@@ -76,6 +78,7 @@ tasks:
     vars:
       OUTPUT: '{{.OUTPUT | default (printf "%s/content/installation/%s.md" .REPO_ROOT .VERSION)}}'
     cmds:
+      - mkdir -p "$(dirname '{{.OUTPUT}}')"
       - >-
         php bin/gen-install-pages.php
         --mode=install
@@ -90,6 +93,7 @@ tasks:
     vars:
       OUTPUT: '{{.OUTPUT | default (printf "%s/content/upgrade/%s.md" .REPO_ROOT .VERSION)}}'
     cmds:
+      - mkdir -p "$(dirname '{{.OUTPUT}}')"
       - >-
         php bin/gen-install-pages.php
         --mode=upgrade
@@ -115,15 +119,17 @@ tasks:
       - php bin/validate-dispatch.php --payload={{.PAYLOAD}}
 
   update-manifest:
-    desc: Apply a dispatch payload to data/releases.json
+    desc: Apply a dispatch payload to a releases.json (defaults to the in-repo copy)
     deps: [setup]
     requires:
       vars: [PAYLOAD]
+    vars:
+      MANIFEST: '{{.MANIFEST | default (printf "%s/data/releases.json" .REPO_ROOT)}}'
     cmds:
       - >-
         php bin/update-manifest.php
         --payload={{.PAYLOAD}}
-        --manifest={{.REPO_ROOT}}/data/releases.json
+        --manifest={{.MANIFEST}}
         --schema={{.REPO_ROOT}}/data/releases.schema.json
 
   lint-aliases:
@@ -172,38 +178,55 @@ tasks:
           jq -r -f contracts/payload-outputs.jq "$payload"
         } >> "$GITHUB_OUTPUT"
 
-  workflow:commit-push:
+  workflow:prepare-publish:
     desc: |
-      Commit anything new in the working tree and force-push it to
-      release-docs/$VERSION. Reports `pushed=true|false` on $GITHUB_OUTPUT.
-    dir: '{{.REPO_ROOT}}'
+      Clone the website-openemr repo into $PUBLISH and check out $BRANCH.
+      Falls back to a fresh branch off master when $BRANCH does not exist
+      remotely yet (first dispatch for a version). The clone uses the App
+      token in the URL — no actions/checkout extraheader interferes.
     cmds:
       - |
-        git config user.name 'openemr-release-bot[bot]'
-        git config user.email 'openemr-release-bot[bot]@users.noreply.github.com'
-        git remote set-url origin \
-          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-        # The first dispatch for a version creates release-docs/$VERSION;
-        # later dispatches in the same release (rel-update, openemr-tag)
-        # check out master and have no local ref for the branch. We need
-        # to (a) build on top of any prior dispatch's artifacts so this
-        # commit doesn't clobber them, and (b) give --force-with-lease a
-        # current baseline so it doesn't reject with "stale info".
-        # Both come from fetching the branch and basing our work on it.
-        if git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
-          git checkout -B "$BRANCH" "origin/${BRANCH}"
+        rm -rf "$PUBLISH"
+        git clone --quiet --depth 1 \
+          "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          "$PUBLISH"
+        git -C "$PUBLISH" config user.name 'openemr-release-bot[bot]'
+        git -C "$PUBLISH" config user.email 'openemr-release-bot[bot]@users.noreply.github.com'
+        if git -C "$PUBLISH" fetch --quiet --depth 1 origin \
+            "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
+          git -C "$PUBLISH" checkout -B "$BRANCH" "origin/${BRANCH}"
         else
           # First dispatch for this version — branch doesn't exist yet.
-          git checkout -B "$BRANCH"
+          # Local branch will spring into existence on first push.
+          git -C "$PUBLISH" checkout -B "$BRANCH"
         fi
-        git add -A
-        if git diff --cached --quiet; then
+
+  workflow:commit-push:
+    desc: |
+      Apply $STAGING on top of $PUBLISH, commit, and force-push to $BRANCH.
+      Reports `pushed=true|false` on $GITHUB_OUTPUT. The $PUBLISH clone
+      already has the App token wired into its origin remote by
+      workflow:prepare-publish.
+    cmds:
+      - |
+        # Generators write under $STAGING. update-manifest writes directly
+        # into $PUBLISH/data/releases.json (it needs the live manifest to
+        # mutate). Both end up here; rsync only copies what's present.
+        if [ -d "$STAGING" ] && [ -n "$(ls -A "$STAGING" 2>/dev/null)" ]; then
+          rsync -a "${STAGING}/" "${PUBLISH}/"
+        fi
+        git -C "$PUBLISH" add -A
+        if git -C "$PUBLISH" diff --cached --quiet; then
           echo 'no docs changes; skipping push'
           echo 'pushed=false' >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        git commit -m "release-docs: ${EVENT} ${VERSION} @ ${SHA:0:12}"
-        git push --force-with-lease origin "HEAD:${BRANCH}"
+        git -C "$PUBLISH" commit -m "release-docs: ${EVENT} ${VERSION} @ ${SHA:0:12}"
+        # --force-with-lease has a real baseline because prepare-publish
+        # checked out origin/$BRANCH (when it existed). For the first
+        # dispatch on a new version, the branch simply doesn't exist
+        # remotely and the push creates it.
+        git -C "$PUBLISH" push --force-with-lease origin "HEAD:${BRANCH}"
         echo 'pushed=true' >> "$GITHUB_OUTPUT"
 
   workflow:upsert-pr:

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -186,6 +186,9 @@ tasks:
       token in the URL — no actions/checkout extraheader interferes.
     cmds:
       - |
+        # $STAGING is created here so commit-push can rsync from it
+        # unconditionally; an empty dir is a harmless no-op for rsync.
+        mkdir -p "$STAGING"
         rm -rf "$PUBLISH"
         git clone --quiet --depth 1 \
           "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
@@ -211,10 +214,9 @@ tasks:
       - |
         # Generators write under $STAGING. update-manifest writes directly
         # into $PUBLISH/data/releases.json (it needs the live manifest to
-        # mutate). Both end up here; rsync only copies what's present.
-        if [ -d "$STAGING" ] && [ -n "$(ls -A "$STAGING" 2>/dev/null)" ]; then
-          rsync -a "${STAGING}/" "${PUBLISH}/"
-        fi
+        # mutate). prepare-publish guarantees $STAGING exists, so rsync
+        # is unconditional — an empty staging dir is a no-op.
+        rsync -a "${STAGING}/" "${PUBLISH}/"
         git -C "$PUBLISH" add -A
         if git -C "$PUBLISH" diff --cached --quiet; then
           echo 'no docs changes; skipping push'


### PR DESCRIPTION
## Summary

Today's chain of release-docs bugs (#102 token plumbing, #104 push-auth extraheader, #106 lease baseline, #108 cumulative-checkout, then #110's branch-switch trick) were all symptoms of one design problem: the workflow's checkout of website-openemr was doubling as the build environment **and** the publish target. Generators wrote into the workspace's `content/` tree as untracked files, then `commit-push` tried to switch branches in that same working tree.

This refactor separates the two roles cleanly:

| Role | Path | Used for |
|--|--|--|
| Build env | `$GITHUB_WORKSPACE` | Composer deps, Taskfile, generator source. Never touched by git ops on website-openemr. |
| Staging | `$RUNNER_TEMP/staging` | Generators write Hugo content here (mirrors repo `content/` tree). |
| Publish target | `$RUNNER_TEMP/publish` | Fresh clone of website-openemr with `$BRANCH` checked out. All git ops happen here. |

A new `workflow:prepare-publish` task does the clone + branch checkout. `workflow:commit-push` rsyncs `$STAGING` over `$PUBLISH`, commits, pushes. `update-manifest` gains a `MANIFEST` var so it can mutate `$PUBLISH/data/releases.json` directly. The sparse-checkout of openemr/openemr also moves to `$RUNNER_TEMP` for symmetry.

## What this kills

- **Checkout-vs-untracked-file conflict** (generators and git ops now have separate working trees).
- **`actions/checkout` extraheader vs URL-credentials race** — the App token is the only auth on the publish clone (the `persist-credentials: false` fix from #104 stays on the workspace checkout as defense in depth).
- **Stale-info `--force-with-lease` failures** — the clone fetches the branch directly, so the lease has a real baseline.
- **Branch-switch gymnastics** in commit-push (`update-ref` / `symbolic-ref` / `reset --mixed` from the closed #110) — no longer needed because the publish clone is fresh.

## What carries over

- Test-mode routing to `release-docs-test/<version>` and skipping the manifest write (from #108).
- `persist-credentials: false` on the workspace checkout (from #104, defensive).
- `.gitignore` of `/.openemr-src` (from #108, also now defensive — the openemr-src checkout no longer lives in the workspace).

## Test plan

- [ ] Existing `release-docs-ci` (phpcs / phpstan / phpunit / validate-fixtures) passes — nothing in CI invokes the changed workflow tasks.
- [ ] After merge, fire a conductor cycle (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.10 -f branch=rel-test -f test=true`), merge the prep PR.
- [ ] Confirm `release-docs-test/8.1.10` carries acknowledgements + release-notes + install + upgrade (cumulative across rel-cut and openemr-tag dispatches).
- [ ] Confirm both rel-cut and tag dispatch runs complete cleanly (no untracked-file or stale-info errors).
- [ ] Confirm `data/releases.json` on master is unchanged.

## Cleanup pending

The stale `release-docs/8.1.{3..7}` PRs and branches from prior debugging cycles still exist; they should be closed and the branches deleted as a separate manual step.

Refs openemr/openemr-devops#664.