### PR TITLE
fix(release-docs): keep .openemr-src in workspace (actions/checkout requires it)

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -95,14 +95,15 @@ jobs:
           persist-credentials: false
 
       # runner.temp isn't available in job-level env, so resolve all
-      # working paths here and export them via GITHUB_ENV. All paths under
-      # $RUNNER_TEMP so the workspace checkout stays a clean build env —
-      # no untracked working-tree files for the generators to leak into
-      # git operations.
+      # working paths here and export them via GITHUB_ENV. STAGING and
+      # PUBLISH live under $RUNNER_TEMP so they can't collide with the
+      # workspace's tracked content. OPENEMR_CHECKOUT has to stay under
+      # $GITHUB_WORKSPACE — actions/checkout refuses paths outside it —
+      # so .openemr-src is gitignored to prevent it from being committed.
       - name: Define working paths
         run: |
           {
-            printf 'OPENEMR_CHECKOUT=%s\n' "$RUNNER_TEMP/openemr-src"
+            printf 'OPENEMR_CHECKOUT=%s\n' "$GITHUB_WORKSPACE/.openemr-src"
             printf 'STAGING=%s\n' "$RUNNER_TEMP/staging"
             printf 'PUBLISH=%s\n' "$RUNNER_TEMP/publish"
           } >> "$GITHUB_ENV"
@@ -173,7 +174,7 @@ jobs:
         with:
           repository: openemr/openemr
           ref: ${{ steps.payload.outputs.sha }}
-          path: ${{ runner.temp }}/openemr-src
+          path: .openemr-src
           fetch-depth: 0
           sparse-checkout: |
             .git


### PR DESCRIPTION
## Summary

The refactor in #111 moved the openemr/openemr sparse-checkout to `$RUNNER_TEMP/openemr-src` for symmetry with `$STAGING` and `$PUBLISH`. `actions/checkout` rejected the run:

```
Repository path '/home/runner/work/_temp/openemr-src' is not under '/home/runner/work/website-openemr/website-openemr'
```

`actions/checkout` enforces that `path:` is under `$GITHUB_WORKSPACE`. Move `.openemr-src` back to the workspace and rely on the `.gitignore` entry from #108 to prevent it from being committed. The publish target still lives in `$RUNNER_TEMP`, so the working-tree-collision class of bug #111 fixed stays fixed.

## Test plan

- [ ] After merge, fire 8.1.11 (`gh workflow run release-prep.yml --repo openemr/openemr --ref master -f target-version=8.1.11 -f branch=rel-test -f test=true`).
- [ ] Confirm the rel-cut + tag dispatches both succeed and produce a cumulative `release-docs-test/8.1.11`.

Refs openemr/openemr-devops#664.