### PR TITLE
fix(deploy): drop Pages baseURL override that broke prod links

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,12 +1,13 @@
-# Builds the site and (on master) deploys it to GitHub Pages staging at
-# https://openemr.github.io/website-openemr/. Production
-# (https://www.open-emr.org/) is not deployed by this workflow — see
-# openemr/website-openemr#92 for the planned prod deploy.
+# Builds the site and (on master) deploys it to GitHub Pages. The Pages
+# site is published both at https://openemr.github.io/website-openemr/
+# and at the custom domain https://www.open-emr.org/ (fronted by
+# Cloudflare); both are served from the same artifact, so the build
+# must use the production baseURL from config.yaml without override.
 #
 # The build job runs on every PR and master push and gates the deploy
 # job behind a Hugo WARN allowlist. Deploy only runs on master push and
-# rebuilds with the Pages base URL — the build job's artifact is a
-# fail-fast gate, not the deployable artifact.
+# rebuilds the site — the build job's artifact is a fail-fast gate,
+# not the deployable artifact.
 name: site
 
 on:
@@ -117,14 +118,8 @@ jobs:
       - name: Install theme dependencies
         working-directory: ./themes/openemr
         run: npm ci
-      - name: Configure Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      # actions/configure-pages emits base_url without a trailing slash
-      # (e.g. https://openemr.github.io/website-openemr). Hugo expects a
-      # trailing slash on baseURL, so append one explicitly.
       - name: Build for deploy
-        run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+        run: hugo --minify
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
## Summary

Production (`https://www.open-emr.org/`) is currently emitting links and asset URLs prefixed with `/website-openemr/` — e.g. the navbar brand link points to `https://openemr.github.io/website-openemr/`, and `/demo` resolves to `https://www.open-emr.org/website-openemr/demo/`. This is because the Pages site at `https://openemr.github.io/website-openemr/` and the custom-domain prod site at `https://www.open-emr.org/` are **served from the same Pages artifact** (Cloudflare in front, GitHub Pages as origin), but the deploy build was overriding `baseURL` to the github.io URL.

PR #93 introduced `hugo --baseURL "${{ steps.pages.outputs.base_url }}/"` to fix an SRI/CORS issue with the fingerprinted CSS link on the github.io staging URL. PR #96 then fixed that SRI problem properly by adding `crossorigin=\"anonymous\"` to the `<link>`. The `--baseURL` override has been redundant since #96 — and it's been actively breaking the production URLs.

This PR drops the override (and the no-longer-needed `actions/configure-pages` step) so the deploy build uses `baseURL: https://www.open-emr.org/` from `config.yaml`. The workflow header comment is updated to reflect that this workflow really is the production deploy, not a staging-only deploy as previously believed.

Verified live: `curl https://www.open-emr.org/` shows the broken `<a class=\"navbar-brand\" href=https://openemr.github.io/website-openemr/>` today; with the override removed that link rebuilds as `https://www.open-emr.org/`.

Refs: #93, #96, #92.

## Test plan

- [ ] After merge, watch the deploy run on master complete
- [ ] Wait for Cloudflare cache to expire (`max-age=600`) or purge
- [ ] Confirm `curl -s https://www.open-emr.org/ | grep -oE 'href=\"[^\"]*website-openemr[^\"]*\"'` returns nothing
- [ ] Confirm `https://www.open-emr.org/demo/` is reachable and that the demo nav link points to `/demo` (not `/website-openemr/demo`)
- [ ] Confirm `https://openemr.github.io/website-openemr/` still loads with styles applied (SRI handled by #96's `crossorigin` attribute)