### PR TITLE
feat(releases): /releases/ and /downloads/ pages driven by data/releases.json

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Download OpenEMR"
+date: 2026-05-13
+url: downloads
+---
+
+# Download OpenEMR
+
+OpenEMR is free and open source. The current stable release is below;
+older versions are listed on the [Releases](/releases/) page.

--- a/content/releases/_index.md
+++ b/content/releases/_index.md
@@ -1,0 +1,11 @@
+---
+title: "OpenEMR Releases"
+date: 2026-05-13
+url: releases
+---
+
+# OpenEMR Releases
+
+Every tagged OpenEMR release, grouped by major version.
+Release notes live on GitHub for 8.x and on the wiki for older versions.
+For the current stable download, see the [Downloads](/downloads/) page.

--- a/data/releases.json
+++ b/data/releases.json
@@ -1,4 +1,132 @@
 {
+    "4.1.0": {
+        "status": "FINAL",
+        "released_at": "2011-09-21",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.0/openemr-4.1.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.0/openemr-4.1.0.zip/download"
+        }
+    },
+    "4.1.1": {
+        "status": "FINAL",
+        "released_at": "2012-08-29",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.1/openemr-4.1.1.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.1/openemr-4.1.1.zip/download"
+        }
+    },
+    "4.1.2": {
+        "status": "FINAL",
+        "released_at": "2013-08-16",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.2/openemr-4.1.2.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.1.2/openemr-4.1.2.zip/download"
+        }
+    },
+    "4.2.0": {
+        "status": "FINAL",
+        "released_at": "2014-12-20",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.0/openemr-4.2.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.0/openemr-4.2.0.zip/download"
+        }
+    },
+    "4.2.1": {
+        "status": "FINAL",
+        "released_at": "2016-03-23",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.1/openemr-4.2.1.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.1/openemr-4.2.1.zip/download"
+        }
+    },
+    "4.2.2": {
+        "status": "FINAL",
+        "released_at": "2016-05-18",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.2/openemr-4.2.2.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.2.2/openemr-4.2.2.zip/download"
+        }
+    },
+    "5.0.0": {
+        "status": "FINAL",
+        "released_at": "2017-02-13",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.0/openemr-5.0.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.0/openemr-5.0.0.zip/download"
+        }
+    },
+    "5.0.1": {
+        "status": "FINAL",
+        "released_at": "2018-04-21",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.1/openemr-5.0.1.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.1/openemr-5.0.1.zip/download"
+        }
+    },
+    "5.0.2": {
+        "status": "FINAL",
+        "released_at": "2019-08-03",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.2/openemr-5.0.2.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/5.0.2/openemr-5.0.2.zip/download"
+        }
+    },
+    "6.0.0": {
+        "status": "FINAL",
+        "released_at": "2021-01-05",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/6.0.0/openemr-6.0.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/6.0.0/openemr-6.0.0.zip/download"
+        }
+    },
+    "6.1.0": {
+        "status": "FINAL",
+        "released_at": "2022-03-20",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/6.1.0/openemr-6.1.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/6.1.0/openemr-6.1.0.zip/download"
+        }
+    },
+    "7.0.0": {
+        "status": "FINAL",
+        "released_at": "2022-07-18",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.0/openemr-7.0.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.0/openemr-7.0.0.zip/download"
+        }
+    },
+    "7.0.1": {
+        "status": "FINAL",
+        "released_at": "2023-04-25",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.1/openemr-7.0.1.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.1/openemr-7.0.1.zip/download"
+        }
+    },
+    "7.0.2": {
+        "status": "FINAL",
+        "released_at": "2023-11-15",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.2/openemr-7.0.2.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.2/openemr-7.0.2.zip/download"
+        }
+    },
+    "7.0.3": {
+        "status": "FINAL",
+        "released_at": "2025-03-19",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.3/openemr-7.0.3.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.3/openemr-7.0.3.zip/download"
+        }
+    },
+    "7.0.4": {
+        "status": "FINAL",
+        "released_at": "2025-12-18",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.4/openemr-7.0.4.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/7.0.4/openemr-7.0.4.zip/download"
+        }
+    },
     "8.0.0": {
         "status": "FINAL",
         "branch": "rel-800",

--- a/data/releases.schema.json
+++ b/data/releases.schema.json
@@ -2,22 +2,23 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://openemr.org/website-openemr/data/releases.schema.json",
     "title": "OpenEMR releases manifest",
-    "description": "Per-version release status, consumed by the release-status Hugo shortcode and written by the release-docs workflow on inbound dispatches from openemr/openemr.",
+    "description": "Per-version release status, consumed by the release-status Hugo shortcode and the /releases/ and /downloads/ pages, and written by the release-docs workflow on inbound dispatches from openemr/openemr. Historical entries (versions that predate the rel-* branch and dispatch automation) carry only status, released_at, and archive_urls; the dispatch writer never touches them.",
     "type": "object",
     "additionalProperties": false,
     "patternProperties": {
         "^\\d+\\.\\d+\\.\\d+$": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["status", "branch", "sha", "released_at"],
+            "required": ["status"],
             "properties": {
                 "status": { "enum": ["DRAFT", "FINAL"] },
                 "branch": {
-                    "description": "Release branch name. Real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut. Matches the canonical dispatch.schema.json branch pattern in openemr/openemr-devops.",
+                    "description": "Release branch name. Real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut. Matches the canonical dispatch.schema.json branch pattern in openemr/openemr-devops. Absent on historical entries that predate the rel-* convention.",
                     "type": "string",
                     "pattern": "^rel-[A-Za-z0-9]+$"
                 },
                 "sha": {
+                    "description": "Commit SHA the dispatch refers to. Absent on historical entries.",
                     "type": "string",
                     "pattern": "^[0-9a-f]{40}$"
                 },
@@ -29,16 +30,41 @@
                             "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
                         }
                     ]
+                },
+                "archive_urls": {
+                    "description": "Direct download URLs for the release tarball and zip. Used for historical entries (mostly SourceForge) where the URL cannot be derived from the version. New dispatch-driven entries derive URLs from the GitHub release at render time and omit this field.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tarball": { "type": "string", "format": "uri" },
+                        "zip": { "type": "string", "format": "uri" }
+                    }
                 }
             },
             "oneOf": [
                 {
+                    "description": "Dispatch-managed DRAFT entry. Always carries branch + sha; released_at is null until the tag flips it to FINAL.",
+                    "required": ["branch", "sha", "released_at"],
                     "properties": {
                         "status": { "const": "DRAFT" },
                         "released_at": { "type": "null" }
                     }
                 },
                 {
+                    "description": "Dispatch-managed FINAL entry. Carries branch + sha from the originating dispatch.",
+                    "required": ["branch", "sha", "released_at"],
+                    "properties": {
+                        "status": { "const": "FINAL" },
+                        "released_at": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                        }
+                    }
+                },
+                {
+                    "description": "Historical FINAL entry. Predates the rel-* branch and dispatch automation; carries only released_at and (optionally) archive_urls.",
+                    "required": ["released_at"],
+                    "not": { "anyOf": [{ "required": ["branch"] }, { "required": ["sha"] }] },
                     "properties": {
                         "status": { "const": "FINAL" },
                         "released_at": {

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -1,0 +1,62 @@
+{{ define "main" }}
+<div style="margin-top: 98px; margin-bottom: 50px">
+    <div class="container page">
+        <div class="row">
+            <div class="col-xs-12 col-md-8 offset-md-2">
+                {{ .Content }}
+
+                {{/* Pick the highest-version FINAL entry as current stable. */}}
+                {{ $finals := slice }}
+                {{ range $version, $entry := .Site.Data.releases }}
+                    {{ if eq $entry.status "FINAL" }}
+                        {{ $finals = $finals | append (dict "version" $version "entry" $entry) }}
+                    {{ end }}
+                {{ end }}
+                {{ $finals = sort $finals "version" "desc" }}
+                {{ $latest := index $finals 0 }}
+
+                {{ with $latest }}
+                    {{ $tag := printf "v%s" (replace .version "." "_") }}
+                    <h2>Stable production release &mdash; version {{ .version }}</h2>
+                    <p>Released {{ .entry.released_at }}.</p>
+
+                    <h3>Download</h3>
+                    <ul>
+                        {{ with .entry.archive_urls }}
+                            <li><a href="{{ .tarball }}">openemr-{{ $latest.version }}.tar.gz</a></li>
+                            <li><a href="{{ .zip }}">openemr-{{ $latest.version }}.zip</a></li>
+                        {{ else }}
+                            <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.tar.gz">openemr-{{ .version }}.tar.gz</a></li>
+                            <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.zip">openemr-{{ .version }}.zip</a></li>
+                        {{ end }}
+                    </ul>
+
+                    <h3>What's in this release</h3>
+                    <ul>
+                        {{ if .entry.archive_urls }}
+                            <li><a href="https://www.open-emr.org/wiki/index.php/Release_Features#Version_{{ .version }}">Release notes (wiki)</a></li>
+                        {{ else }}
+                            <li><a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">Release notes (GitHub)</a></li>
+                        {{ end }}
+                        <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_ONC_Certification">ONC Ambulatory EHR certification resources</a></li>
+                    </ul>
+                {{ end }}
+
+                <h2>Development versions</h2>
+                <p>For testing the bleeding edge, the development Docker images are published continuously to Docker Hub:</p>
+                <ul>
+                    <li><a href="https://hub.docker.com/r/openemr/openemr/">openemr/openemr on Docker Hub</a></li>
+                </ul>
+                <p>For installing development snapshots from source:</p>
+                <ul>
+                    <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Development_Version_Linux_Installation">Linux installation</a></li>
+                    <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Development_Version_Windows_Installation">Windows installation</a></li>
+                </ul>
+
+                <h2>Older versions</h2>
+                <p>Every previous release is listed on the <a href="/releases/">Releases</a> page.</p>
+            </div>
+        </div>
+    </div>
+</div>
+{{ end }}

--- a/layouts/section/releases.html
+++ b/layouts/section/releases.html
@@ -1,0 +1,85 @@
+{{ define "main" }}
+<div style="margin-top: 98px; margin-bottom: 50px">
+    <div class="container page">
+        <div class="row">
+            <div class="col-xs-12 col-md-10 offset-md-1">
+                {{ .Content }}
+
+                {{ $rows := slice }}
+                {{ range $version, $entry := .Site.Data.releases }}
+                    {{ if eq $entry.status "FINAL" }}
+                        {{ $rows = $rows | append (dict
+                            "version" $version
+                            "entry" $entry
+                            "major" (index (split $version ".") 0)) }}
+                    {{ end }}
+                {{ end }}
+                {{ $rows = sort $rows "version" "desc" }}
+
+                {{ $currentMajor := "" }}
+                {{ range $rows }}
+                    {{ if ne .major $currentMajor }}
+                        {{ if ne $currentMajor "" }}
+                            </tbody></table>
+                        {{ end }}
+                        {{ $currentMajor = .major }}
+                        <h2 id="v{{ .major }}-x">{{ .major }}.x</h2>
+                        <table class="release-history">
+                            <thead>
+                                <tr>
+                                    <th>Version</th>
+                                    <th>Released</th>
+                                    <th>Release notes</th>
+                                    <th>Download</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                    {{ end }}
+
+                    {{ $tag := printf "v%s" (replace .version "." "_") }}
+                    <tr>
+                        <td><strong>{{ .version }}</strong></td>
+                        <td>{{ .entry.released_at }}</td>
+                        <td>
+                            {{ if .entry.archive_urls }}
+                                <a href="https://www.open-emr.org/wiki/index.php/Release_Features#Version_{{ .version }}">notes (wiki)</a>
+                            {{ else }}
+                                <a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">notes (GitHub)</a>
+                            {{ end }}
+                        </td>
+                        <td>
+                            {{ with .entry.archive_urls }}
+                                <a href="{{ .tarball }}">tar.gz</a>
+                                &nbsp;|&nbsp;
+                                <a href="{{ .zip }}">zip</a>
+                            {{ else }}
+                                <a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.tar.gz">tar.gz</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.zip">zip</a>
+                            {{ end }}
+                        </td>
+                    </tr>
+                {{ end }}
+                {{ if ne $currentMajor "" }}
+                    </tbody></table>
+                {{ end }}
+            </div>
+        </div>
+    </div>
+</div>
+<style type="text/css">
+    table.release-history {
+        width: 100%;
+        margin-bottom: 30px;
+    }
+    table.release-history th,
+    table.release-history td {
+        padding: 6px 12px;
+        border-bottom: 1px solid #eee;
+    }
+    table.release-history th {
+        text-align: left;
+        background: #f7f7f7;
+    }
+</style>
+{{ end }}

--- a/tools/release-docs/src/Manifest/ReleasesManifest.php
+++ b/tools/release-docs/src/Manifest/ReleasesManifest.php
@@ -56,8 +56,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null>> $manifest
-     * @return array<string, array<string, string|null>>
+     * @param array<string, array<string, string|null|array<string, string>>> $manifest
+     * @return array<string, array<string, string|null|array<string, string>>>
      */
     private function applyRelCut(array $manifest, DispatchEvent $event): array
     {
@@ -72,8 +72,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null>> $manifest
-     * @return array<string, array<string, string|null>>
+     * @param array<string, array<string, string|null|array<string, string>>> $manifest
+     * @return array<string, array<string, string|null|array<string, string>>>
      */
     private function applyRelUpdate(array $manifest, DispatchEvent $event): array
     {
@@ -91,8 +91,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null>> $manifest
-     * @return array<string, array<string, string|null>>
+     * @param array<string, array<string, string|null|array<string, string>>> $manifest
+     * @return array<string, array<string, string|null|array<string, string>>>
      */
     private function applyTag(array $manifest, DispatchEvent $event): array
     {
@@ -114,7 +114,7 @@ final class ReleasesManifest
     }
 
     /**
-     * @return array<string, array<string, string|null>>
+     * @return array<string, array<string, string|null|array<string, string>>>
      */
     private function load(): array
     {
@@ -150,7 +150,7 @@ final class ReleasesManifest
 
     /**
      * @param array<int|string, mixed> $entry
-     * @return array<string, string|null>
+     * @return array<string, string|null|array<string, string>>
      */
     private function normalizeEntry(array $entry): array
     {
@@ -159,17 +159,38 @@ final class ReleasesManifest
             if (!is_string($key)) {
                 throw new RuntimeException('manifest entry keys must be strings');
             }
-            if ($value !== null && !is_string($value)) {
-                throw new RuntimeException("manifest entry $key must be string or null");
+            if ($value === null || is_string($value)) {
+                $result[$key] = $value;
+                continue;
             }
-            $result[$key] = $value;
+            if (is_array($value)) {
+                $result[$key] = $this->normalizeStringMap($key, $value);
+                continue;
+            }
+            throw new RuntimeException("manifest entry $key must be string, null, or string-keyed string map");
         }
 
         return $result;
     }
 
     /**
-     * @param array<string, array<string, string|null>> $manifest
+     * @param array<int|string, mixed> $value
+     * @return array<string, string>
+     */
+    private function normalizeStringMap(string $parentKey, array $value): array
+    {
+        $sub = [];
+        foreach ($value as $k => $v) {
+            if (!is_string($k) || !is_string($v)) {
+                throw new RuntimeException("manifest entry $parentKey.$k must be string");
+            }
+            $sub[$k] = $v;
+        }
+        return $sub;
+    }
+
+    /**
+     * @param array<string, array<string, string|null|array<string, string>>> $manifest
      */
     private function validate(array $manifest): void
     {
@@ -202,7 +223,7 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null>> $manifest
+     * @param array<string, array<string, string|null|array<string, string>>> $manifest
      */
     private function save(array $manifest): void
     {

--- a/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
+++ b/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
@@ -177,6 +177,52 @@ final class ReleasesManifestApplyTest extends TestCase
         self::assertSame(['8.0.0', '8.2.0'], array_keys($manifest));
     }
 
+    public function testHistoricalEntryPreservedAcrossDispatch(): void
+    {
+        $this->seed([
+            '5.0.2' => [
+                'status' => 'FINAL',
+                'released_at' => '2018-08-23',
+                'archive_urls' => [
+                    'tarball' => 'https://sourceforge.net/projects/openemr/files/'
+                        . 'OpenEMR%20Current/5.0.2/openemr-5.0.2.tar.gz/download',
+                    'zip' => 'https://sourceforge.net/projects/openemr/files/'
+                        . 'OpenEMR%20Current/5.0.2/openemr-5.0.2.zip/download',
+                ],
+            ],
+            '8.0.0' => [
+                'status' => 'FINAL',
+                'branch' => 'rel-800',
+                'sha' => 'b91b73600327acb46252b9fce7d04467eea126fd',
+                'released_at' => '2026-02-13',
+            ],
+        ]);
+
+        $this->manifest()->apply(new DispatchEvent(
+            event: 'openemr-rel-cut',
+            version: '8.1.0',
+            branch: 'rel-810',
+            sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            releasedAt: null,
+        ));
+
+        $manifest = $this->readManifest();
+        self::assertSame(['5.0.2', '8.0.0', '8.1.0'], array_keys($manifest));
+        self::assertSame(
+            [
+                'status' => 'FINAL',
+                'released_at' => '2018-08-23',
+                'archive_urls' => [
+                    'tarball' => 'https://sourceforge.net/projects/openemr/files/'
+                        . 'OpenEMR%20Current/5.0.2/openemr-5.0.2.tar.gz/download',
+                    'zip' => 'https://sourceforge.net/projects/openemr/files/'
+                        . 'OpenEMR%20Current/5.0.2/openemr-5.0.2.zip/download',
+                ],
+            ],
+            $manifest['5.0.2'],
+        );
+    }
+
     public function testFromJsonExtractsRequiredFields(): void
     {
         $payload = json_encode([
@@ -207,7 +253,7 @@ final class ReleasesManifestApplyTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, string|null>> $contents
+     * @param array<string, array<string, string|null|array<string, string>>> $contents
      */
     private function seed(array $contents): void
     {
@@ -216,7 +262,7 @@ final class ReleasesManifestApplyTest extends TestCase
     }
 
     /**
-     * @return array<string, array<string, string|null>>
+     * @return array<string, array<string, string|null|array<string, string>>>
      */
     private function readManifest(): array
     {
@@ -229,7 +275,7 @@ final class ReleasesManifestApplyTest extends TestCase
             throw new RuntimeException('manifest decoded to non-array in test');
         }
 
-        /** @var array<string, array<string, string|null>> */
+        /** @var array<string, array<string, string|null|array<string, string>>> */
         return $decoded;
     }
 }


### PR DESCRIPTION
## Summary

Closes #120 (release-process automation gap #5; tracked under [openemr/openemr-devops#706](https://github.com/openemr/openemr-devops/issues/706)).

Two new Hugo section pages template over `data/releases.json` so the next OpenEMR release self-publishes its download links and a new history row, without anyone touching the wiki:

- **`/releases/`** — every tagged release, grouped by major (8.x, 7.x, …), newest first.
- **`/downloads/`** — current stable release (latest FINAL entry in the manifest) with archive links, release-notes link, ONC certification pointer, and a development-version block.

The release-docs workflow already updates `data/releases.json` on every dispatch (`DRAFT` on `rel-cut`/`rel-update`, `FINAL` on `openemr-tag`), so on every build that follows a tag the new pages re-render with the new version. No new generator code; no workflow changes.

## What's in this PR

- **Schema (`data/releases.schema.json`)** — widened so historical entries (which predate the `rel-*` branch and dispatch automation) validate. `branch` and `sha` are now optional; modern dispatch-managed entries still carry and require both via the existing oneOf branches. New optional `archive_urls` object (`tarball`, `zip`) carries SourceForge URLs for historical rows.
- **Manifest (`data/releases.json`)** — backfilled with 16 historical FINAL entries from 4.1.0 through 7.0.4. Dates sourced from upstream `openemr/openemr` git tags; archive URLs from the consistent SourceForge path used on the existing wiki Downloads page.
- **`tools/release-docs/src/Manifest/ReleasesManifest.php`** — `normalizeEntry` widened to accept the nested `archive_urls` map. Modern dispatch writes are unchanged.
- **`tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php`** — new `testHistoricalEntryPreservedAcrossDispatch` covers a manifest containing a historical entry + a modern entry; an inbound dispatch leaves the historical row untouched.
- **`content/releases/_index.md` + `layouts/section/releases.html`** — page + section template. Layout filters to FINAL, sorts by version desc, emits an `<h2>{major}.x</h2>` whenever the major changes, then a row per version. Notes link → wiki Release_Features anchor for historical, GitHub release page for modern. Download cell → `archive_urls` for historical, GitHub auto-archive (`/archive/refs/tags/v{X}_{Y}_{Z}.{tar.gz,zip}`) for modern.
- **`content/downloads/_index.md` + `layouts/section/downloads.html`** — picks the highest-version FINAL entry as current stable, renders archive links + release notes + ONC link, plus a Development Versions block (Docker Hub, dev-install wiki pages) and an "Older versions → /releases/" footer.

## What this PR does *not* do

- **Wiki page replacement.** The MediaWiki [OpenEMR Downloads](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads) page lives on a different host; Hugo aliases can't redirect into it. Once this PR ships, that page should be edited by hand to a one-line pointer to https://www.open-emr.org/downloads/. Filed as a manual follow-up.
- **Updating the homepage \"Download for Free\" card** which still points at the wiki — left as a follow-up so this PR is just the new pages.

## Test plan

- [x] `composer check` (phpcs + phpstan + phpunit) green in `tools/release-docs/`.
- [x] New `testHistoricalEntryPreservedAcrossDispatch` covers the schema widening and write-side tolerance.
- [x] Local Hugo build succeeds; rendered `/releases/` shows 5 major-version groups (8.x through 4.x) with correct GitHub vs SourceForge URLs per row.
- [x] Local Hugo build of `/downloads/` shows 8.0.0 as current stable with GitHub auto-archive links.
- [x] Round-tripped a fake `openemr-tag` payload for `8.1.0` through `bin/update-manifest.php`, rebuilt Hugo, confirmed the new row appears in both pages.
- [x] Spot-checked one historical SourceForge URL, the GitHub release page URL, and the wiki Release_Features anchor — all return 200.