### PR TITLE
feat(downloads): add Docker section and runtime compatibility info

### DIFF
--- a/data/releases.json
+++ b/data/releases.json
@@ -131,6 +131,27 @@
         "status": "FINAL",
         "branch": "rel-800",
         "sha": "b91b73600327acb46252b9fce7d04467eea126fd",
-        "released_at": "2026-02-13"
+        "released_at": "2026-02-13",
+        "compatibility": {
+            "php":     { "min": "8.2",  "max": "8.5"  },
+            "mariadb": { "min": "10.6", "max": "11.8" },
+            "mysql":   { "min": "5.7",  "max": "8.4"  },
+            "recommended_db": "MariaDB"
+        },
+        "downloads": {
+            "docker": {
+                "install_url": "https://community.open-emr.org/t/openemr-official-docker-has-been-released/9084"
+            },
+            "linux": {
+                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
+                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0",
+                "checksums_url": "https://eight.openemr.io/files/openemr-linux-md5.txt"
+            },
+            "windows": {
+                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
+                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0",
+                "checksums_url": "https://eight.openemr.io/files/openemr-windows-md5.txt"
+            }
+        }
     }
 }

--- a/data/releases.schema.json
+++ b/data/releases.schema.json
@@ -5,6 +5,17 @@
     "description": "Per-version release status, consumed by the release-status Hugo shortcode and the /releases/ and /downloads/ pages, and written by the release-docs workflow on inbound dispatches from openemr/openemr. Historical entries (versions that predate the rel-* branch and dispatch automation) carry only status, released_at, and archive_urls; the dispatch writer never touches them.",
     "type": "object",
     "additionalProperties": false,
+    "$defs": {
+        "versionRange": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["min", "max"],
+            "properties": {
+                "min": { "type": "string" },
+                "max": { "type": "string" }
+            }
+        }
+    },
     "patternProperties": {
         "^\\d+\\.\\d+\\.\\d+$": {
             "type": "object",
@@ -38,6 +49,50 @@
                     "properties": {
                         "tarball": { "type": "string", "format": "uri" },
                         "zip": { "type": "string", "format": "uri" }
+                    }
+                },
+                "compatibility": {
+                    "description": "Supported runtime versions for this release, surfaced on the /downloads/ page. Each component carries an inclusive min/max version range. recommended_db (when set) names the database the project recommends when both MariaDB and MySQL are supported.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "php":     { "$ref": "#/$defs/versionRange" },
+                        "mariadb": { "$ref": "#/$defs/versionRange" },
+                        "mysql":   { "$ref": "#/$defs/versionRange" },
+                        "recommended_db": { "enum": ["MariaDB", "MySQL"] }
+                    }
+                },
+                "downloads": {
+                    "description": "Per-platform download metadata surfaced on the /downloads/ page. Every field is optional; absent fields are simply not rendered.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "docker": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "install_url": { "type": "string", "format": "uri" },
+                                "upgrade_url": { "type": "string", "format": "uri" }
+                            }
+                        },
+                        "linux": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "install_url":   { "type": "string", "format": "uri" },
+                                "upgrade_url":   { "type": "string", "format": "uri" },
+                                "checksums_url": { "type": "string", "format": "uri" }
+                            }
+                        },
+                        "windows": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "install_url":   { "type": "string", "format": "uri" },
+                                "upgrade_url":   { "type": "string", "format": "uri" },
+                                "checksums_url": { "type": "string", "format": "uri" }
+                            }
+                        }
                     }
                 }
             },

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -20,14 +20,53 @@
                     <h2>Stable production release &mdash; version {{ .version }}</h2>
                     <p>Released {{ .entry.released_at }}.</p>
 
-                    <h3>Download</h3>
+                    {{ with .entry.compatibility }}
+                        <p>
+                            Compatibility:
+                            {{ with .php }}PHP {{ .min }}&ndash;{{ .max }}{{ end }}{{ if and .php (or .mariadb .mysql) }}, {{ end }}
+                            {{ with .mariadb }}MariaDB {{ .min }}&ndash;{{ .max }}{{ end }}{{ if and .mariadb .mysql }}, {{ end }}
+                            {{ with .mysql }}MySQL {{ .min }}&ndash;{{ .max }}{{ end }}.
+                            {{ with .recommended_db }}{{ . }} is recommended.{{ end }}
+                        </p>
+                    {{ end }}
+
+                    {{ $dl := .entry.downloads | default dict }}
+
+                    <h3>Docker (recommended)</h3>
+                    <p>The official OpenEMR Docker image is the recommended way to run OpenEMR.</p>
+                    <ul>
+                        <li><a href="https://hub.docker.com/r/openemr/openemr">openemr/openemr on Docker Hub</a></li>
+                        {{ with $dl.docker }}
+                            {{ with .install_url }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+                            {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
+                        {{ end }}
+                    </ul>
+
+                    <h3>Linux</h3>
                     <ul>
                         {{ with .entry.archive_urls }}
                             <li><a href="{{ .tarball }}">openemr-{{ $latest.version }}.tar.gz</a></li>
-                            <li><a href="{{ .zip }}">openemr-{{ $latest.version }}.zip</a></li>
                         {{ else }}
                             <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.tar.gz">openemr-{{ .version }}.tar.gz</a></li>
+                        {{ end }}
+                        {{ with $dl.linux }}
+                            {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
+                            {{ with .install_url }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+                            {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
+                        {{ end }}
+                    </ul>
+
+                    <h3>Windows</h3>
+                    <ul>
+                        {{ with .entry.archive_urls }}
+                            <li><a href="{{ .zip }}">openemr-{{ $latest.version }}.zip</a></li>
+                        {{ else }}
                             <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.zip">openemr-{{ .version }}.zip</a></li>
+                        {{ end }}
+                        {{ with $dl.windows }}
+                            {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
+                            {{ with .install_url }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+                            {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
                     </ul>
 


### PR DESCRIPTION
Closes #124.

The wiki Downloads page has two pieces the Hugo `/downloads/` page was missing:

1. A Docker section (the recommended install path), placed above the Linux tar/zip downloads.
2. Compatibility info for the current stable release: supported PHP / MariaDB / MySQL ranges and the recommended database.

This PR adds both, data-driven through `data/releases.json` so the existing release-docs dispatch flow can populate them on future entries.

## Changes

- `data/releases.schema.json`: optional `compatibility` (PHP / MariaDB / MySQL min-max + `recommended_db`) and `downloads.{docker,linux,windows}` (install / upgrade / checksum URLs) on each release entry. A shared `versionRange` `$def` keeps the three runtime ranges identically shaped.
- `data/releases.json`: populates both blocks for 8.0.0, sourced from the [wiki Downloads page](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads). Historical entries are untouched.
- `layouts/section/downloads.html`: renders the compatibility line, then `Docker (recommended)` → `Linux` → `Windows` sections. Each link is wrapped in `{{ with }}` so absent fields render no row — historical entries that only carry `archive_urls` keep their current behavior.

## Out of scope (per #124)

- AWS Cloud packages, patches, modules / daily snapshots / dev Docker — separate page candidates, deferred.

## Verification

- `jq` validates the JSON and `check-jsonschema data/releases.schema.json data/releases.json` passes.
- `hugo` builds clean; the rendered `/downloads/` page now shows compatibility, the Docker section above Linux, and per-platform install/upgrade/checksum links for 8.0.0.