### PR TITLE
ci(release): switch token mint to client-id var

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -128,7 +128,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Mint App token
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Mint App token
         id: token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.1
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -48,7 +48,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           # Allow the minted token to dispatch into the cross-repo target
           # in addition to this repo. The App must be installed on both.

--- a/content/release-automation-plan.md
+++ b/content/release-automation-plan.md
@@ -121,7 +121,8 @@ In dependency order:
 ## Permissions self-check
 
 `.github/workflows/release-permissions-check.yml` (manual `workflow_dispatch`).
-Mints an App token from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` and
+Mints an App token from the `RELEASE_APP_CLIENT_ID` org variable +
+`RELEASE_APP_PRIVATE_KEY` org secret and
 probes what this repo's docs workflow performs:
 
 - `GET /installation/repositories` — confirm this repo is in the install list.


### PR DESCRIPTION
The `RELEASE_APP_ID` org secret was deleted in favor of a `RELEASE_APP_CLIENT_ID` org variable (see openemr/openemr-devops#701). `actions/create-github-app-token` accepts `client-id` as the preferred input (`app-id` is deprecated), so this swaps both workflows over and updates the plan doc to match.

Files touched:
- `.github/workflows/release-docs.yml`
- `.github/workflows/release-permissions-check.yml`
- `content/release-automation-plan.md`

Private-key references are unchanged.