### PR TITLE
ci: fix create-github-app-token pin (v3.1 → v3)

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Mint App token
         id: token
-        uses: actions/create-github-app-token@v3.1
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v3.1
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The `actions/create-github-app-token@v3.1` pin used in `release-docs.yml` and `release-permissions-check.yml` does not exist as a tag — published versions are `v3.0.0`, `v3.1.0`, `v3.1.1`, `v3.2.0`. Every run fails at action resolution:

> Unable to resolve action \`actions/create-github-app-token@v3.1\`, unable to find version \`v3.1\`

This is blocking the openemr/openemr 8.1.0 release-prep dispatch (openemr/openemr#12285) — the cross-repo `openemr-rel-cut` event fires the `release-docs` workflow, which fails before it can open the docs PR.

Switch to the major-version tag `@v3` to match the convention already used in `openemr/openemr-devops/.github/workflows/dependabot-auto-merge.yml`.

## Test plan

- [ ] CI green
- [ ] Re-dispatch `openemr-rel-cut` from openemr/openemr#12285 (or push an empty commit on rel-810) and confirm the 8.1.0 docs PR opens