### PR TITLE
fix(release-docs): allow nested objects in manifest entries

### DIFF
--- a/tools/release-docs/src/Manifest/ReleasesManifest.php
+++ b/tools/release-docs/src/Manifest/ReleasesManifest.php
@@ -56,8 +56,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $manifest
-     * @return array<string, array<string, string|null|array<string, string>>>
+     * @param array<string, array<string, mixed>> $manifest
+     * @return array<string, array<string, mixed>>
      */
     private function applyRelCut(array $manifest, DispatchEvent $event): array
     {
@@ -72,8 +72,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $manifest
-     * @return array<string, array<string, string|null|array<string, string>>>
+     * @param array<string, array<string, mixed>> $manifest
+     * @return array<string, array<string, mixed>>
      */
     private function applyRelUpdate(array $manifest, DispatchEvent $event): array
     {
@@ -91,8 +91,8 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $manifest
-     * @return array<string, array<string, string|null|array<string, string>>>
+     * @param array<string, array<string, mixed>> $manifest
+     * @return array<string, array<string, mixed>>
      */
     private function applyTag(array $manifest, DispatchEvent $event): array
     {
@@ -114,7 +114,7 @@ final class ReleasesManifest
     }
 
     /**
-     * @return array<string, array<string, string|null|array<string, string>>>
+     * @return array<string, array<string, mixed>>
      */
     private function load(): array
     {
@@ -149,8 +149,14 @@ final class ReleasesManifest
     }
 
     /**
+     * Normalize a decoded manifest entry. Only enforces that keys are strings
+     * and leaf values are scalar (string) or null; the JSON schema validator
+     * is the authoritative check on structural shape, so nested objects
+     * (compatibility.php = {min, max}, downloads.docker = {install_url}, etc.)
+     * pass through unchanged.
+     *
      * @param array<int|string, mixed> $entry
-     * @return array<string, string|null|array<string, string>>
+     * @return array<string, mixed>
      */
     private function normalizeEntry(array $entry): array
     {
@@ -159,38 +165,32 @@ final class ReleasesManifest
             if (!is_string($key)) {
                 throw new RuntimeException('manifest entry keys must be strings');
             }
-            if ($value === null || is_string($value)) {
-                $result[$key] = $value;
-                continue;
-            }
-            if (is_array($value)) {
-                $result[$key] = $this->normalizeStringMap($key, $value);
-                continue;
-            }
-            throw new RuntimeException("manifest entry $key must be string, null, or string-keyed string map");
+            $result[$key] = $this->normalizeValue($key, $value);
         }
 
         return $result;
     }
 
-    /**
-     * @param array<int|string, mixed> $value
-     * @return array<string, string>
-     */
-    private function normalizeStringMap(string $parentKey, array $value): array
+    private function normalizeValue(string $path, mixed $value): mixed
     {
+        if ($value === null || is_string($value)) {
+            return $value;
+        }
+        if (!is_array($value)) {
+            throw new RuntimeException("manifest entry $path must be string, null, or string-keyed object");
+        }
         $sub = [];
         foreach ($value as $k => $v) {
-            if (!is_string($k) || !is_string($v)) {
-                throw new RuntimeException("manifest entry $parentKey.$k must be string");
+            if (!is_string($k)) {
+                throw new RuntimeException("manifest entry $path.$k keys must be strings");
             }
-            $sub[$k] = $v;
+            $sub[$k] = $this->normalizeValue("$path.$k", $v);
         }
         return $sub;
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $manifest
+     * @param array<string, array<string, mixed>> $manifest
      */
     private function validate(array $manifest): void
     {
@@ -223,7 +223,7 @@ final class ReleasesManifest
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $manifest
+     * @param array<string, array<string, mixed>> $manifest
      */
     private function save(array $manifest): void
     {

--- a/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
+++ b/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
@@ -223,6 +223,53 @@ final class ReleasesManifestApplyTest extends TestCase
         );
     }
 
+    public function testEntryWithNestedCompatibilityAndDownloadsLoads(): void
+    {
+        $this->seed([
+            '8.0.0' => [
+                'status' => 'FINAL',
+                'branch' => 'rel-800',
+                'sha' => 'b91b73600327acb46252b9fce7d04467eea126fd',
+                'released_at' => '2026-02-13',
+                'compatibility' => [
+                    'php' => ['min' => '8.2', 'max' => '8.5'],
+                    'mariadb' => ['min' => '10.6', 'max' => '11.8'],
+                    'recommended_db' => 'MariaDB',
+                ],
+                'downloads' => [
+                    'docker' => ['install_url' => 'https://example.invalid/docker'],
+                ],
+            ],
+        ]);
+
+        $this->manifest()->apply(new DispatchEvent(
+            event: 'openemr-rel-cut',
+            version: '8.1.0',
+            branch: 'rel-810',
+            sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            releasedAt: null,
+        ));
+
+        $manifest = $this->readManifest();
+        self::assertSame(
+            [
+                'status' => 'FINAL',
+                'branch' => 'rel-800',
+                'sha' => 'b91b73600327acb46252b9fce7d04467eea126fd',
+                'released_at' => '2026-02-13',
+                'compatibility' => [
+                    'php' => ['min' => '8.2', 'max' => '8.5'],
+                    'mariadb' => ['min' => '10.6', 'max' => '11.8'],
+                    'recommended_db' => 'MariaDB',
+                ],
+                'downloads' => [
+                    'docker' => ['install_url' => 'https://example.invalid/docker'],
+                ],
+            ],
+            $manifest['8.0.0'],
+        );
+    }
+
     public function testFromJsonExtractsRequiredFields(): void
     {
         $payload = json_encode([
@@ -253,7 +300,7 @@ final class ReleasesManifestApplyTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, string|null|array<string, string>>> $contents
+     * @param array<string, array<string, mixed>> $contents
      */
     private function seed(array $contents): void
     {
@@ -262,7 +309,7 @@ final class ReleasesManifestApplyTest extends TestCase
     }
 
     /**
-     * @return array<string, array<string, string|null|array<string, string>>>
+     * @return array<string, array<string, mixed>>
      */
     private function readManifest(): array
     {
@@ -275,7 +322,7 @@ final class ReleasesManifestApplyTest extends TestCase
             throw new RuntimeException('manifest decoded to non-array in test');
         }
 
-        /** @var array<string, array<string, string|null|array<string, string>>> */
+        /** @var array<string, array<string, mixed>> */
         return $decoded;
     }
 }


### PR DESCRIPTION
## Summary

The manifest normalizer in `ReleasesManifest::normalizeStringMap` only handled flat `{string: string}` maps, so loading any existing entry with `compatibility.php = {min, max}` (or `downloads.docker = {install_url}`, etc.) threw:

```
manifest entry compatibility.php must be string
```

…and aborted the dispatch. This blocks the 8.1.0 release flow: `openemr-rel-cut` and `openemr-rel-update` both fail before they can render the docs PR, so the release manager has nothing to edit.

The JSON schema validator (`data/releases.schema.json`) is already the authoritative check on structural shape, so the normalizer doesn't need to police nesting depth. Let arbitrarily nested string-keyed objects pass through, and let the schema reject anything malformed.

## Test plan

- [x] New regression test seeds an entry with `compatibility` (nested versionRange objects) + `downloads`, applies a dispatch, asserts the existing entry round-trips intact
- [x] `composer test` — 69/69
- [x] `composer phpstan` — clean
- [x] `composer phpcs` — clean

Unblocks: openemr/openemr#12285 (8.1.0 release prep).