### PR TITLE
fix(release-docs): use /repos/.../pulls to dodge search 1000-cap

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -224,11 +224,20 @@ tasks:
           exit 0
         fi
         git -C "$PUBLISH" commit -m "release-docs: ${EVENT} ${VERSION} @ ${SHA:0:12}"
-        # --force-with-lease has a real baseline because prepare-publish
-        # checked out origin/$BRANCH (when it existed). For the first
-        # dispatch on a new version, the branch simply doesn't exist
-        # remotely and the push creates it.
-        git -C "$PUBLISH" push --force-with-lease origin "HEAD:${BRANCH}"
+        # --force-with-lease needs an explicit expected baseline. The
+        # local branch isn't tracking origin/$BRANCH (prepare-publish
+        # does `checkout -B`, not `--track`), so a bare --force-with-lease
+        # has no @{upstream} to read and the server rejects with
+        # "stale info". When the remote-tracking ref doesn't exist (first
+        # dispatch for this version), fall back to a plain push that
+        # creates the branch.
+        if base=$(git -C "$PUBLISH" rev-parse --verify --quiet "refs/remotes/origin/${BRANCH}"); then
+          git -C "$PUBLISH" push \
+            --force-with-lease="refs/heads/${BRANCH}:${base}" \
+            origin "HEAD:${BRANCH}"
+        else
+          git -C "$PUBLISH" push origin "HEAD:${BRANCH}"
+        fi
         echo 'pushed=true' >> "$GITHUB_OUTPUT"
 
   workflow:upsert-pr:

--- a/tools/release-docs/src/ReleaseNotesGenerator.php
+++ b/tools/release-docs/src/ReleaseNotesGenerator.php
@@ -96,10 +96,29 @@ final class ReleaseNotesGenerator
      */
     public function fetchMergedPullRequests(string $owner, string $repo, string $from, string $to): array
     {
+        // List-pulls is used in preference to /search/issues because the
+        // Search API caps results at 1000 — OpenEMR routinely exceeds
+        // that in a release window. /repos/{o}/{r}/pulls has no such cap.
+        $fromTs = self::parseBoundary($from, startOfDay: true);
+        $toTs = self::parseBoundary($to, startOfDay: false);
         $items = [];
-        foreach ($this->fetchPages($owner, $repo, $from, $to) as $page) {
-            foreach ($page as $item) {
-                $items[] = $item;
+        foreach ($this->fetchClosedPullPages($owner, $repo) as $page) {
+            foreach ($page as $pull) {
+                $updatedAt = self::parseTimestamp($pull, 'updated_at');
+                if ($updatedAt < $fromTs) {
+                    // Sorted by updated desc — anything past this point
+                    // updated before our window can't have merged in it.
+                    return $this->parseItems($items);
+                }
+                $mergedAtRaw = $pull['merged_at'] ?? null;
+                if (!is_string($mergedAtRaw) || $mergedAtRaw === '') {
+                    continue;
+                }
+                $mergedAt = strtotime($mergedAtRaw);
+                if ($mergedAt === false || $mergedAt < $fromTs || $mergedAt > $toTs) {
+                    continue;
+                }
+                $items[] = $pull;
             }
         }
 
@@ -107,15 +126,15 @@ final class ReleaseNotesGenerator
     }
 
     /**
-     * Yield successive pages of search results until a short page signals
-     * the end. The caller never sees the page index.
+     * Yield pages of closed PRs sorted by updated_at desc until a short
+     * page signals the end.
      *
      * @return Generator<int, list<array<int|string, mixed>>>
      */
-    private function fetchPages(string $owner, string $repo, string $from, string $to): Generator
+    private function fetchClosedPullPages(string $owner, string $repo): Generator
     {
         for ($page = 1;; $page++) {
-            $batch = $this->fetchPage($owner, $repo, $from, $to, $page);
+            $batch = $this->fetchClosedPullPage($owner, $repo, $page);
             yield $batch;
             if (count($batch) < self::PER_PAGE) {
                 return;
@@ -126,11 +145,13 @@ final class ReleaseNotesGenerator
     /**
      * @return list<array<int|string, mixed>>
      */
-    private function fetchPage(string $owner, string $repo, string $from, string $to, int $page): array
+    private function fetchClosedPullPage(string $owner, string $repo, int $page): array
     {
-        $response = $this->client->request('GET', '/search/issues', [
+        $response = $this->client->request('GET', "/repos/$owner/$repo/pulls", [
             'query' => [
-                'q' => "repo:$owner/$repo is:pr is:merged merged:$from..$to",
+                'state' => 'closed',
+                'sort' => 'updated',
+                'direction' => 'desc',
                 'per_page' => self::PER_PAGE,
                 'page' => $page,
             ],
@@ -138,22 +159,46 @@ final class ReleaseNotesGenerator
         $body = (string) $response->getBody();
         $payload = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
         if (!is_array($payload)) {
-            throw new RuntimeException('GitHub search API returned a non-array payload');
-        }
-        $items = $payload['items'] ?? null;
-        if (!is_array($items)) {
-            throw new RuntimeException('GitHub search API payload missing items[]');
+            throw new RuntimeException('GitHub pulls API returned a non-array payload');
         }
 
         $normalized = [];
-        foreach ($items as $item) {
+        foreach ($payload as $item) {
             if (!is_array($item)) {
-                throw new RuntimeException('GitHub search API item is not an array');
+                throw new RuntimeException('GitHub pulls API item is not an array');
             }
             $normalized[] = $item;
         }
 
         return $normalized;
+    }
+
+    private static function parseBoundary(string $date, bool $startOfDay): int
+    {
+        $suffix = $startOfDay ? 'T00:00:00Z' : 'T23:59:59Z';
+        $ts = strtotime($date . $suffix);
+        if ($ts === false) {
+            throw new RuntimeException("Invalid date boundary: $date");
+        }
+
+        return $ts;
+    }
+
+    /**
+     * @param array<int|string, mixed> $pull
+     */
+    private static function parseTimestamp(array $pull, string $field): int
+    {
+        $raw = $pull[$field] ?? null;
+        if (!is_string($raw) || $raw === '') {
+            throw new RuntimeException("PR field \"$field\" missing or not non-empty string");
+        }
+        $ts = strtotime($raw);
+        if ($ts === false) {
+            throw new RuntimeException("PR field \"$field\" not a parseable timestamp: $raw");
+        }
+
+        return $ts;
     }
 
     /**

--- a/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
+++ b/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
@@ -115,15 +115,14 @@ final class ReleaseNotesGeneratorTest extends TestCase
     {
         $page1Items = [];
         for ($i = 1; $i <= 100; $i++) {
-            $page1Items[] = self::apiItem($i, 'feat: pr ' . $i);
+            $page1Items[] = self::apiItem($i, 'feat: pr ' . $i, '2026-04-29T12:00:00Z');
         }
         $page2Items = [
-            self::apiItem(101, 'fix: pr 101'),
-            self::apiItem(102, 'chore: pr 102'),
+            self::apiItem(101, 'fix: pr 101', '2026-04-28T12:00:00Z'),
+            self::apiItem(102, 'chore: pr 102', '2026-04-27T12:00:00Z'),
         ];
-        $envelope = ['total_count' => 102, 'incomplete_results' => false];
-        $page1 = json_encode($envelope + ['items' => $page1Items], JSON_THROW_ON_ERROR);
-        $page2 = json_encode($envelope + ['items' => $page2Items], JSON_THROW_ON_ERROR);
+        $page1 = json_encode($page1Items, JSON_THROW_ON_ERROR);
+        $page2 = json_encode($page2Items, JSON_THROW_ON_ERROR);
 
         $mock = new MockHandler([new Response(200, [], $page1), new Response(200, [], $page2)]);
         $client = new Client(['handler' => HandlerStack::create($mock)]);
@@ -134,6 +133,57 @@ final class ReleaseNotesGeneratorTest extends TestCase
         self::assertCount(102, $prs);
         self::assertSame(1, $prs[0]['number']);
         self::assertSame(102, $prs[101]['number']);
+    }
+
+    public function testFetchMergedPullRequestsStopsAtWindowBoundary(): void
+    {
+        $page1 = json_encode([
+            self::apiItem(10, 'feat: in window', '2026-04-20T12:00:00Z'),
+            self::apiItem(11, 'fix: in window edge', '2026-02-13T00:00:01Z'),
+            self::apiItem(12, 'chore: before window', '2026-02-01T12:00:00Z'),
+        ], JSON_THROW_ON_ERROR);
+
+        // Second response is queued to prove early-exit doesn't fetch it.
+        $mock = new MockHandler([
+            new Response(200, [], $page1),
+            new Response(500, [], 'must not be called'),
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $prs = (new ReleaseNotesGenerator($client))
+            ->fetchMergedPullRequests('openemr', 'openemr', '2026-02-13', '2026-04-29');
+
+        self::assertSame([10, 11], array_column($prs, 'number'));
+    }
+
+    public function testFetchMergedPullRequestsSkipsClosedWithoutMerge(): void
+    {
+        $page1 = json_encode([
+            [
+                'number' => 1,
+                'title' => 'feat: merged',
+                'html_url' => 'https://example.test/1',
+                'user' => ['login' => 'alice'],
+                'merged_at' => '2026-04-20T12:00:00Z',
+                'updated_at' => '2026-04-20T12:00:00Z',
+            ],
+            [
+                'number' => 2,
+                'title' => 'feat: closed without merge',
+                'html_url' => 'https://example.test/2',
+                'user' => ['login' => 'bob'],
+                'merged_at' => null,
+                'updated_at' => '2026-04-19T12:00:00Z',
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $mock = new MockHandler([new Response(200, [], $page1)]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $prs = (new ReleaseNotesGenerator($client))
+            ->fetchMergedPullRequests('openemr', 'openemr', '2026-02-13', '2026-04-29');
+
+        self::assertSame([1], array_column($prs, 'number'));
     }
 
     /**
@@ -152,13 +202,15 @@ final class ReleaseNotesGeneratorTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private static function apiItem(int $number, string $title): array
+    private static function apiItem(int $number, string $title, string $mergedAt): array
     {
         return [
             'number' => $number,
             'title' => $title,
             'html_url' => "https://github.com/openemr/openemr/pull/$number",
             'user' => ['login' => 'tester'],
+            'merged_at' => $mergedAt,
+            'updated_at' => $mergedAt,
         ];
     }
 

--- a/tools/release-docs/tests/fixtures/release-notes/api-page1.json
+++ b/tools/release-docs/tests/fixtures/release-notes/api-page1.json
@@ -1,36 +1,42 @@
-{
-    "total_count": 5,
-    "incomplete_results": false,
-    "items": [
-        {
-            "number": 8123,
-            "title": "feat: add encounter export",
-            "html_url": "https://github.com/openemr/openemr/pull/8123",
-            "user": { "login": "alice" }
-        },
-        {
-            "number": 8124,
-            "title": "fix: encounter list pagination",
-            "html_url": "https://github.com/openemr/openemr/pull/8124",
-            "user": { "login": "bob" }
-        },
-        {
-            "number": 8125,
-            "title": "refactor: extract patient finder",
-            "html_url": "https://github.com/openemr/openemr/pull/8125",
-            "user": { "login": "carol" }
-        },
-        {
-            "number": 8126,
-            "title": "chore: bump twig",
-            "html_url": "https://github.com/openemr/openemr/pull/8126",
-            "user": { "login": "dave" }
-        },
-        {
-            "number": 8127,
-            "title": "Fix typo in README",
-            "html_url": "https://github.com/openemr/openemr/pull/8127",
-            "user": { "login": "eve" }
-        }
-    ]
-}
+[
+    {
+        "number": 8123,
+        "title": "feat: add encounter export",
+        "html_url": "https://github.com/openemr/openemr/pull/8123",
+        "user": { "login": "alice" },
+        "merged_at": "2026-04-28T12:00:00Z",
+        "updated_at": "2026-04-28T12:00:00Z"
+    },
+    {
+        "number": 8124,
+        "title": "fix: encounter list pagination",
+        "html_url": "https://github.com/openemr/openemr/pull/8124",
+        "user": { "login": "bob" },
+        "merged_at": "2026-04-25T12:00:00Z",
+        "updated_at": "2026-04-25T12:00:00Z"
+    },
+    {
+        "number": 8125,
+        "title": "refactor: extract patient finder",
+        "html_url": "https://github.com/openemr/openemr/pull/8125",
+        "user": { "login": "carol" },
+        "merged_at": "2026-04-20T12:00:00Z",
+        "updated_at": "2026-04-20T12:00:00Z"
+    },
+    {
+        "number": 8126,
+        "title": "chore: bump twig",
+        "html_url": "https://github.com/openemr/openemr/pull/8126",
+        "user": { "login": "dave" },
+        "merged_at": "2026-04-15T12:00:00Z",
+        "updated_at": "2026-04-15T12:00:00Z"
+    },
+    {
+        "number": 8127,
+        "title": "Fix typo in README",
+        "html_url": "https://github.com/openemr/openemr/pull/8127",
+        "user": { "login": "eve" },
+        "merged_at": "2026-04-10T12:00:00Z",
+        "updated_at": "2026-04-10T12:00:00Z"
+    }
+]


### PR DESCRIPTION
## Summary

`release-docs.yml` has failed on every recent dispatch (rel-cut, rel-update, openemr-tag). Root cause: the release-notes generator paginates `/search/issues` with `is:pr is:merged merged:$from..$to`. The Search API caps results at 1000 — OpenEMR's release window exceeds that, so page 11 returns `422 Unprocessable Entity: "Only the first 1000 search results are available"`, the generator throws, and the workflow exits 255.

Switch to `/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc`. No 1000-cap. Filter `merged_at` ∈ window client-side and early-exit once `updated_at` crosses below `from` (since `updated_at >= merged_at` always, this bound is safe).

`parseItems` is unchanged — list-pulls items share the `number`/`title`/`html_url`/`user.login` shape with search items.

## Test plan

- [x] `composer check` (phpcs + phpstan + 71 tests) green locally
- [x] New tests: window-boundary early-exit, skip closed-without-merge
- [x] Snapshot test (`expected-8.1.0.md`) still matches — output rendering unchanged
- [ ] `workflow_dispatch` from this branch regenerates release-docs/8.1.0 against the live openemr/openemr (link added once green)
- [ ] Verify DRAFT→FINAL flip still works on a simulated `openemr-tag` dispatch

Closes the release-docs leg of the 8.1.0 fan-out failure.