### PR TITLE
fix(release-docs): link release tarball to GitHub Release asset

### DIFF
--- a/tools/release-docs/src/InstallPagesGenerator.php
+++ b/tools/release-docs/src/InstallPagesGenerator.php
@@ -29,6 +29,7 @@ final class InstallPagesGenerator
     {
         return $this->renderTemplate('install.md.template', [
             '__VERSION__' => $version,
+            '__VERSION_TAG__' => AcknowledgementsGenerator::tagForVersion($version),
             '__MIN_PHP__' => $minPhp,
         ]);
     }
@@ -40,6 +41,7 @@ final class InstallPagesGenerator
     ): string {
         return $this->renderTemplate('upgrade.md.template', [
             '__VERSION__' => $version,
+            '__VERSION_TAG__' => AcknowledgementsGenerator::tagForVersion($version),
             '__PREVIOUS_VERSION__' => $previousVersion,
             '__MIN_PHP__' => $minPhp,
         ]);

--- a/tools/release-docs/templates/install.md.template
+++ b/tools/release-docs/templates/install.md.template
@@ -18,7 +18,7 @@ version: "__VERSION__"
 
 Download the OpenEMR __VERSION__ release tarball:
 
-- [openemr-__VERSION__.tar.gz](https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/__VERSION__/openemr-__VERSION__.tar.gz/download)
+- [openemr-__VERSION__.tar.gz](https://github.com/openemr/openemr/releases/download/__VERSION_TAG__/openemr-__VERSION__.tar.gz)
 
 ## Install
 

--- a/tools/release-docs/templates/upgrade.md.template
+++ b/tools/release-docs/templates/upgrade.md.template
@@ -21,7 +21,7 @@ Before starting any upgrade, take a full backup of:
 
 ## Upgrade steps
 
-1. Download the [openemr-__VERSION__.tar.gz](https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/__VERSION__/openemr-__VERSION__.tar.gz/download) tarball.
+1. Download the [openemr-__VERSION__.tar.gz](https://github.com/openemr/openemr/releases/download/__VERSION_TAG__/openemr-__VERSION__.tar.gz) tarball.
 2. Extract the tarball alongside the existing installation; do not overwrite
    the existing `sites/` directory.
 3. Browse to `https://your-server/openemr-__VERSION__/sql_upgrade.php` and run

--- a/tools/release-docs/tests/fixtures/install-pages/expected-install-8.1.0.md
+++ b/tools/release-docs/tests/fixtures/install-pages/expected-install-8.1.0.md
@@ -18,7 +18,7 @@ version: "8.1.0"
 
 Download the OpenEMR 8.1.0 release tarball:
 
-- [openemr-8.1.0.tar.gz](https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.1.0/openemr-8.1.0.tar.gz/download)
+- [openemr-8.1.0.tar.gz](https://github.com/openemr/openemr/releases/download/v8_1_0/openemr-8.1.0.tar.gz)
 
 ## Install
 

--- a/tools/release-docs/tests/fixtures/install-pages/expected-upgrade-8.1.0-from-8.0.0.md
+++ b/tools/release-docs/tests/fixtures/install-pages/expected-upgrade-8.1.0-from-8.0.0.md
@@ -21,7 +21,7 @@ Before starting any upgrade, take a full backup of:
 
 ## Upgrade steps
 
-1. Download the [openemr-8.1.0.tar.gz](https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.1.0/openemr-8.1.0.tar.gz/download) tarball.
+1. Download the [openemr-8.1.0.tar.gz](https://github.com/openemr/openemr/releases/download/v8_1_0/openemr-8.1.0.tar.gz) tarball.
 2. Extract the tarball alongside the existing installation; do not overwrite
    the existing `sites/` directory.
 3. Browse to `https://your-server/openemr-8.1.0/sql_upgrade.php` and run


### PR DESCRIPTION
## Summary

The generated per-release install and upgrade pages still linked the release tarball to SourceForge. SourceForge is no longer a distribution target — the GitHub Release object is now the canonical (and only) distribution target for `openemr/openemr` (see `docs/RELEASE_PROCESS.md`).

This repoints the generator templates at the GitHub Release **asset**:

```
https://github.com/openemr/openemr/releases/download/<TAG>/openemr-<VERSION>.tar.gz
```

- Adds a `__VERSION_TAG__` placeholder, supplied in both `renderInstall()` and `renderUpgrade()` via the existing `AcknowledgementsGenerator::tagForVersion()` helper (e.g. `8.1.0` → `v8_1_0`).
- Updates `install.md.template` and `upgrade.md.template`.
- Updates the snapshot fixtures the generator tests compare against byte-for-byte.

The link text stays `openemr-<VERSION>.tar.gz`, which now matches the actual downloaded filename.

Fixing the source templates (not the regenerated release-docs PR's committed files) is the correct fix, since that PR is force-regenerated from these templates on every dispatch.

## Test plan

- [x] `composer test` — all 71 tests green (snapshot + placeholder-guard)
- [x] `composer phpcs` — clean
- [x] Manual render of both modes produces the GitHub asset URL with no `__...__` leftovers
- [ ] After merge: re-dispatch the release-docs workflow and confirm the regenerated PR diff no longer contains `sourceforge`