### PR TITLE
feat(release-docs): filter release-machinery noise from release notes

### DIFF
--- a/tools/release-docs/src/ReleaseNotesGenerator.php
+++ b/tools/release-docs/src/ReleaseNotesGenerator.php
@@ -56,6 +56,24 @@ final class ReleaseNotesGenerator
         'Other',
     ];
 
+    /**
+     * Bot login whose PRs are pure release machinery, never user-facing.
+     */
+    private const RELEASE_BOT = 'openemr-release-bot[bot]';
+
+    /**
+     * Dependabot login; its same-version no-op re-pins are dropped.
+     */
+    private const DEPENDABOT = 'dependabot[bot]';
+
+    /**
+     * Conventional-Commits scopes that mark a PR as release automation
+     * rather than a user-facing change.
+     *
+     * @var list<string>
+     */
+    private const MACHINERY_SCOPES = ['release', 'release-prep'];
+
     public function __construct(
         private readonly ClientInterface $client,
     ) {
@@ -63,7 +81,12 @@ final class ReleaseNotesGenerator
 
     public function generate(string $owner, string $repo, string $from, string $to, string $version): string
     {
-        return $this->render($this->groupByPrefix($this->fetchMergedPullRequests($owner, $repo, $from, $to)), $version);
+        return $this->render(
+            $this->groupByPrefix(
+                $this->filterNoise($this->fetchMergedPullRequests($owner, $repo, $from, $to)),
+            ),
+            $version,
+        );
     }
 
     /**
@@ -238,6 +261,71 @@ final class ReleaseNotesGenerator
         }
 
         return $result;
+    }
+
+    /**
+     * Drop PRs that are release machinery or other non-user-facing noise:
+     * release-bot commits, [TEST] dry-run PRs, same-version dependabot
+     * no-op bumps, release/release-prep-scoped automation, and the
+     * duplicate half of a backport pair (the original is kept).
+     *
+     * @param list<array{number: int, title: string, url: string, author: string}> $prs
+     * @return list<array{number: int, title: string, url: string, author: string}>
+     */
+    public function filterNoise(array $prs): array
+    {
+        return array_values(array_filter($prs, static fn (array $pr): bool => !self::isNoise($pr)));
+    }
+
+    /**
+     * @param array{number: int, title: string, url: string, author: string} $pr
+     */
+    private static function isNoise(array $pr): bool
+    {
+        $title = $pr['title'];
+        if ($pr['author'] === self::RELEASE_BOT) {
+            return true;
+        }
+        if (stripos($title, '[TEST]') !== false) {
+            return true;
+        }
+        if (stripos($title, 'backport') !== false) {
+            return true;
+        }
+        if (in_array(self::scopeOf($title), self::MACHINERY_SCOPES, true)) {
+            return true;
+        }
+        if (preg_match('/^chore(?:\([^)]*\))?:\s*release\b/i', $title) === 1) {
+            return true;
+        }
+
+        return $pr['author'] === self::DEPENDABOT && self::isNoOpVersionBump($title);
+    }
+
+    /**
+     * Lowercased Conventional-Commits scope, or null when the title has no
+     * parseable "type(scope):" prefix.
+     */
+    private static function scopeOf(string $title): ?string
+    {
+        if (preg_match('/^\w+\(([^)]*)\)!?:/', $title, $matches) !== 1) {
+            return null;
+        }
+
+        return strtolower($matches[1]);
+    }
+
+    /**
+     * True for a dependabot "bump <dep> from <v> to <v>" title where the two
+     * versions are identical — a re-pin that changes nothing.
+     */
+    private static function isNoOpVersionBump(string $title): bool
+    {
+        if (preg_match('/\bfrom\s+(\S+)\s+to\s+(\S+)/', $title, $matches) !== 1) {
+            return false;
+        }
+
+        return $matches[1] === $matches[2];
     }
 
     /**

--- a/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
+++ b/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
@@ -90,6 +90,29 @@ final class ReleaseNotesGeneratorTest extends TestCase
         self::assertCount(2, $groups['Other']);
     }
 
+    public function testFilterNoiseDropsMachineryAndKeepsRealChanges(): void
+    {
+        $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
+
+        $kept = $generator->filterNoise([
+            self::authored(1, 'feat(api): real feature', 'alice'),
+            self::authored(2, 'chore(release): prep 8.1.0', 'openemr-release-bot[bot]'),
+            self::authored(3, 'feat: experimental [TEST] thing', 'bob'),
+            self::authored(4, 'chore(deps): bump redis from 8.8.0 to 8.8.0', 'dependabot[bot]'),
+            self::authored(5, 'chore(deps): bump twig/twig from 3.25.0 to 3.26.0', 'dependabot[bot]'),
+            self::authored(6, 'fix(release): widen dispatch branch pattern', 'carol'),
+            self::authored(7, 'fix(release-prep): stop bumping docker-version files', 'carol'),
+            self::authored(8, 'fix(encounter): handle null uuid (backport #999)', 'carol'),
+            self::authored(9, 'chore: release 8.1.0 misc', 'dave'),
+            self::authored(10, 'fix(ui): keep me', 'erin'),
+        ]);
+
+        // Kept: real feature, real (different-version) dep bump, real fix.
+        // Dropped: release bot, [TEST], no-op bump, release/release-prep
+        // scopes, backport duplicate, and the "chore: release" straggler.
+        self::assertSame([1, 5, 10], array_column($kept, 'number'));
+    }
+
     public function testFullPipelineMatchesFixtureSnapshot(): void
     {
         $body = self::loadFixture('api-page1.json');
@@ -196,6 +219,19 @@ final class ReleaseNotesGeneratorTest extends TestCase
             'title' => $title,
             'url' => "https://example.test/$number",
             'author' => 'tester',
+        ];
+    }
+
+    /**
+     * @return array{number: int, title: string, url: string, author: string}
+     */
+    private static function authored(int $number, string $title, string $author): array
+    {
+        return [
+            'number' => $number,
+            'title' => $title,
+            'url' => "https://example.test/$number",
+            'author' => $author,
         ];
     }
 

--- a/tools/release-docs/tests/fixtures/release-notes/api-page1.json
+++ b/tools/release-docs/tests/fixtures/release-notes/api-page1.json
@@ -38,5 +38,53 @@
         "user": { "login": "eve" },
         "merged_at": "2026-04-10T12:00:00Z",
         "updated_at": "2026-04-10T12:00:00Z"
+    },
+    {
+        "number": 8200,
+        "title": "chore(release): prep 8.1.0",
+        "html_url": "https://github.com/openemr/openemr/pull/8200",
+        "user": { "login": "openemr-release-bot[bot]" },
+        "merged_at": "2026-04-08T12:00:00Z",
+        "updated_at": "2026-04-08T12:00:00Z"
+    },
+    {
+        "number": 8201,
+        "title": "feat: experimental thing [TEST]",
+        "html_url": "https://github.com/openemr/openemr/pull/8201",
+        "user": { "login": "mallory" },
+        "merged_at": "2026-04-07T12:00:00Z",
+        "updated_at": "2026-04-07T12:00:00Z"
+    },
+    {
+        "number": 8202,
+        "title": "chore(deps): bump redis from 8.8.0 to 8.8.0 in /docker/development-insane in the redis group across 1 directory",
+        "html_url": "https://github.com/openemr/openemr/pull/8202",
+        "user": { "login": "dependabot[bot]" },
+        "merged_at": "2026-04-06T12:00:00Z",
+        "updated_at": "2026-04-06T12:00:00Z"
+    },
+    {
+        "number": 8203,
+        "title": "fix(release): widen dispatch branch pattern to allow rel-test",
+        "html_url": "https://github.com/openemr/openemr/pull/8203",
+        "user": { "login": "trent" },
+        "merged_at": "2026-04-05T12:00:00Z",
+        "updated_at": "2026-04-05T12:00:00Z"
+    },
+    {
+        "number": 8204,
+        "title": "fix(encounter): handle missing row and null uuid (backport #8124)",
+        "html_url": "https://github.com/openemr/openemr/pull/8204",
+        "user": { "login": "trent" },
+        "merged_at": "2026-04-04T12:00:00Z",
+        "updated_at": "2026-04-04T12:00:00Z"
+    },
+    {
+        "number": 8205,
+        "title": "chore: release 8.1.0 misc",
+        "html_url": "https://github.com/openemr/openemr/pull/8205",
+        "user": { "login": "trent" },
+        "merged_at": "2026-04-03T12:00:00Z",
+        "updated_at": "2026-04-03T12:00:00Z"
     }
 ]


### PR DESCRIPTION
## What

Adds a `filterNoise()` pass to `ReleaseNotesGenerator` (run before bucketing) that drops non-user-facing PRs from the generated release notes:

- PRs authored by `openemr-release-bot[bot]`
- `[TEST]` dry-run PRs
- Same-version dependabot no-op re-pins (e.g. `bump redis from 8.8.0 to 8.8.0`)
- Release automation scoped `(release)` / `(release-prep)`, plus `chore: release …` stragglers
- The backport half of a pair (the original PR is kept)

Real, different-version dependency bumps and all genuine user-facing changes are unaffected.

## Why

The generator rendered every merged PR in the window. For 8.1.0 that meant the notes ran ~1000 lines, dominated by machinery churn and duplicate backport entries — see the draft on the 8.1.0 docs PR. Filtering at the generator (rather than hand-editing the generated page) is the only fix that survives, because the docs branch is force-pushed wholesale on every dispatch.

## Tests

- New unit test asserts each noise category is dropped and real changes (incl. a different-version dep bump) survive.
- The full-pipeline snapshot fixture gains six noise entries; the expected output is unchanged, proving they're filtered end-to-end.
- `composer check` (phpcs + phpstan + phpunit) green.

## Rollout note

To clean the in-flight 8.1.0 notes, the `release-docs/8.1.0` workflow needs a re-run (`workflow_dispatch`) after this merges, before the final ship dispatch.