### PR TITLE
feat(release-docs): regenerate EHI (b)(10) SchemaSpy docs in CI, publish via git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Versioned EHI (b)(10) SchemaSpy docs are large generated HTML/asset trees.
+# Track the whole published subtree with git-lfs so the Hugo repo stays lean.
+static/documentation/*/b10/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
       - uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: ${{ env.HUGO_VERSION }}
@@ -108,6 +110,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
       - uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: ${{ env.HUGO_VERSION }}

--- a/.github/workflows/release-docs-ci.yml
+++ b/.github/workflows/release-docs-ci.yml
@@ -81,6 +81,64 @@ jobs:
       - run: composer install --no-interaction --no-progress --prefer-dist
       - run: composer test
 
+  gen-ehi-smoke:
+    name: gen-ehi smoke (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04]
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_DATABASE: openemr
+          MARIADB_USER: openemr
+          MARIADB_PASSWORD: openemr
+          MARIADB_ROOT_PASSWORD: openemr
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          tools: composer:v2
+          coverage: none
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: arduino/setup-task@v2
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: composer install --no-interaction --no-progress --prefer-dist
+      - name: Sparse-checkout EHI assets from openemr master
+        uses: actions/checkout@v6
+        with:
+          repository: openemr/openemr
+          ref: master
+          path: .openemr-src
+          sparse-checkout: |
+            sql/database.sql
+            Documentation/EHI_Export/b10-tables.yml
+            Documentation/EHI_Export/schemaspy
+      - name: Generate EHI docs to a temp dir and assert index.html
+        env:
+          OPENEMR_CHECKOUT: ${{ github.workspace }}/.openemr-src
+          STAGING: ${{ runner.temp }}/ehi-smoke
+          VERSION: smoke
+          FALLBACK: 'false'
+        run: |
+          task workflow:gen-ehi
+          test -f "$STAGING/static/documentation/$VERSION/b10/index.html"
+
   validate-fixtures:
     name: validate dispatch fixtures (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -84,6 +84,25 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-24.04]
+    # Schema-only source for the EHI (b)(10) SchemaSpy run. Always declared
+    # (services can't be conditional) but only used by the gated EHI steps;
+    # on DRAFT dispatches it idles. db/user/pass = openemr to match the
+    # installer defaults the schemaspy invocation expects.
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_DATABASE: openemr
+          MARIADB_USER: openemr
+          MARIADB_PASSWORD: openemr
+          MARIADB_ROOT_PASSWORD: openemr
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v6
@@ -180,6 +199,50 @@ jobs:
             .git
             version.php
             CHANGELOG.md
+            sql/database.sql
+            Documentation/EHI_Export/b10-tables.yml
+            Documentation/EHI_Export/schemaspy
+
+      # EHI (b)(10) regen is a heavyweight Java+DB step; run it only for
+      # FINAL tags and manual dispatches. `fallback` flags the retroactive
+      # 8.1.0 case whose tagged sha predates b10-tables.yml, so its assets
+      # must come from openemr master instead of the tagged checkout.
+      - name: Resolve EHI (b)(10) generation
+        id: ehi
+        env:
+          EVENT: ${{ steps.payload.outputs.event }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = 'openemr-tag' ] || [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+            echo 'EHI (b)(10) regen runs only on openemr-tag or workflow_dispatch; skipping.'
+          fi
+          if [ -f "$OPENEMR_CHECKOUT/Documentation/EHI_Export/b10-tables.yml" ]; then
+            echo 'fallback=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'fallback=true' >> "$GITHUB_OUTPUT"
+            echo 'Tagged sha predates b10-tables.yml; EHI assets will come from openemr master.'
+          fi
+
+      - name: Sparse-checkout EHI assets from openemr master (8.1.0 fallback)
+        if: ${{ steps.ehi.outputs.enabled == 'true' && steps.ehi.outputs.fallback == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          repository: openemr/openemr
+          ref: master
+          path: .openemr-ehi-fallback
+          sparse-checkout: |
+            Documentation/EHI_Export/b10-tables.yml
+            Documentation/EHI_Export/schemaspy
+
+      - name: Set up Java for SchemaSpy
+        if: ${{ steps.ehi.outputs.enabled == 'true' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
 
       - name: Prepare staging + publish-target
         env:
@@ -230,6 +293,13 @@ jobs:
           VERSION="$VERSION"
           PREVIOUS_VERSION="$PREV"
           OUTPUT="$STAGING/content/upgrade/$VERSION.md"
+
+      - name: Generate EHI (b)(10) schema docs
+        if: ${{ steps.ehi.outputs.enabled == 'true' }}
+        env:
+          VERSION: ${{ steps.payload.outputs.version }}
+          FALLBACK: ${{ steps.ehi.outputs.fallback }}
+        run: task workflow:gen-ehi
 
       - name: Update releases manifest
         if: ${{ steps.mode.outputs.test != 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ GitHub.sublime-settings
 
 # release-docs sparse checkout of openemr/openemr (input for generators)
 /.openemr-src
+# release-docs fallback checkout of openemr master EHI assets (retroactive 8.1.0)
+/.openemr-ehi-fallback

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -101,6 +101,33 @@ tasks:
         --previous-version={{.PREVIOUS_VERSION}}
         --output={{.OUTPUT}}
 
+  gen-ehi:
+    desc: Regenerate the EHI (b)(10) SchemaSpy documentation for a release
+    deps: [setup]
+    requires:
+      vars: [OPENEMR_CHECKOUT, VERSION]
+    vars:
+      OUTPUT: '{{.OUTPUT | default (printf "%s/static/documentation/%s/b10/" .REPO_ROOT .VERSION)}}'
+      DB_HOST: '{{.DB_HOST | default "127.0.0.1"}}'
+      DB_PORT: '{{.DB_PORT | default "3306"}}'
+      DB_NAME: '{{.DB_NAME | default "openemr"}}'
+      DB_USER: '{{.DB_USER | default "openemr"}}'
+      DB_PASSWORD: '{{.DB_PASSWORD | default "openemr"}}'
+      DB_SCHEMA: '{{.DB_SCHEMA | default "openemr"}}'
+    cmds:
+      - mkdir -p '{{.OUTPUT}}'
+      - >-
+        php bin/gen-ehi.php
+        --openemr-checkout={{.OPENEMR_CHECKOUT}}
+        --release-version={{.VERSION}}
+        --output={{.OUTPUT}}
+        --db-host={{.DB_HOST}}
+        --db-port={{.DB_PORT}}
+        --db-name={{.DB_NAME}}
+        --db-user={{.DB_USER}}
+        --db-password={{.DB_PASSWORD}}
+        --db-schema={{.DB_SCHEMA}}
+
   apply-aliases:
     desc: Merge wiki-URL aliases into Hugo page frontmatter
     deps: [setup]
@@ -195,6 +222,9 @@ tasks:
           "$PUBLISH"
         git -C "$PUBLISH" config user.name 'openemr-release-bot[bot]'
         git -C "$PUBLISH" config user.email 'openemr-release-bot[bot]@users.noreply.github.com'
+        # Enable LFS clean filters locally so committing the b10 docs tree
+        # captures it as LFS objects (per the repo-root .gitattributes rule).
+        git -C "$PUBLISH" lfs install --local
         if git -C "$PUBLISH" fetch --quiet --depth 1 origin \
             "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
           git -C "$PUBLISH" checkout -B "$BRANCH" "origin/${BRANCH}"
@@ -287,6 +317,40 @@ tasks:
            "$PAYLOAD" > "$sub"
         gh api -X POST /repos/openemr/website-openemr-files/dispatches \
           --input "$sub"
+
+  workflow:gen-ehi:
+    desc: |
+      Load the fresh-install schema into the MariaDB service and regenerate
+      the EHI (b)(10) SchemaSpy docs into
+      $STAGING/static/documentation/$VERSION/b10/. Table set + schemaspy
+      assets come from $OPENEMR_CHECKOUT; when $FALLBACK is 'true' (tagged sha
+      predates b10-tables.yml — the retroactive 8.1.0 path) they come from the
+      openemr-master checkout at $GITHUB_WORKSPACE/.openemr-ehi-fallback while
+      the schema is still loaded from the tagged sha's sql/database.sql.
+    cmds:
+      - |
+        db_host="${DB_HOST:-127.0.0.1}"
+        db_port="${DB_PORT:-3306}"
+        db_name="${DB_NAME:-openemr}"
+        db_user="${DB_USER:-openemr}"
+        db_password="${DB_PASSWORD:-openemr}"
+        mysql -h"$db_host" -P"$db_port" -u"$db_user" -p"$db_password" "$db_name" \
+          < "$OPENEMR_CHECKOUT/sql/database.sql"
+        ehi_src="$OPENEMR_CHECKOUT/Documentation/EHI_Export"
+        if [ "${FALLBACK:-false}" = 'true' ]; then
+          ehi_src="$GITHUB_WORKSPACE/.openemr-ehi-fallback/Documentation/EHI_Export"
+        fi
+        php bin/gen-ehi.php \
+          --openemr-checkout="$OPENEMR_CHECKOUT" \
+          --release-version="$VERSION" \
+          --output="$STAGING/static/documentation/$VERSION/b10/" \
+          --tables-file="$ehi_src/b10-tables.yml" \
+          --schemaspy-dir="$ehi_src/schemaspy" \
+          --db-host="$db_host" \
+          --db-port="$db_port" \
+          --db-name="$db_name" \
+          --db-user="$db_user" \
+          --db-password="$db_password"
 
   workflow:strip-sidecar:
     desc: |

--- a/tools/release-docs/bin/gen-ehi.php
+++ b/tools/release-docs/bin/gen-ehi.php
@@ -1,0 +1,79 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Regenerate the EHI / ONC (b)(10) SchemaSpy documentation for a release.
+ *
+ * Loads the (b)(10) table set and bundled SchemaSpy assets from an
+ * openemr/openemr checkout, then runs schemaspy.jar against an already-loaded
+ * schema to produce a browsable HTML tree under --output.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+use OpenEMR\ReleaseDocs\Cli\Options;
+use OpenEMR\ReleaseDocs\EhiSchemaGenerator;
+use OpenEMR\ReleaseDocs\EhiSchemaSpyConfig;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$command = new class () extends Command {
+    protected function configure(): void
+    {
+        $this
+            ->setName('gen-ehi')
+            ->setDescription('Regenerate the EHI (b)(10) SchemaSpy documentation for a release.')
+            ->addOption('openemr-checkout', null, InputOption::VALUE_REQUIRED, 'Path to an openemr/openemr checkout')
+            ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'Directory to write the SchemaSpy HTML tree')
+            ->addOption('db-host', null, InputOption::VALUE_REQUIRED, 'Database host', '127.0.0.1')
+            ->addOption('db-port', null, InputOption::VALUE_REQUIRED, 'Database port', '3306')
+            ->addOption('db-name', null, InputOption::VALUE_REQUIRED, 'Database name', 'openemr')
+            ->addOption('db-user', null, InputOption::VALUE_REQUIRED, 'Database user', 'openemr')
+            ->addOption('db-password', null, InputOption::VALUE_REQUIRED, 'Database password', 'openemr')
+            ->addOption('db-schema', null, InputOption::VALUE_REQUIRED, 'Database schema', 'openemr')
+            ->addOption('tables-file', null, InputOption::VALUE_REQUIRED, 'Override path to b10-tables.yml')
+            ->addOption('schemaspy-dir', null, InputOption::VALUE_REQUIRED, 'Override path to the schemaspy asset dir');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $config = EhiSchemaSpyConfig::fromOpenemrCheckout(
+            openemrCheckout: Options::requireString($input, 'openemr-checkout'),
+            outputDir: Options::requireString($input, 'output'),
+            dbHost: Options::requireString($input, 'db-host'),
+            dbPort: (int) Options::requireString($input, 'db-port'),
+            dbName: Options::requireString($input, 'db-name'),
+            dbUser: Options::requireString($input, 'db-user'),
+            dbPassword: Options::requireString($input, 'db-password'),
+            dbSchema: Options::requireString($input, 'db-schema'),
+            tablesFile: Options::optionalString($input, 'tables-file'),
+            schemaspyDir: Options::optionalString($input, 'schemaspy-dir'),
+        );
+
+        (new EhiSchemaGenerator())->generate($config);
+
+        $output->writeln("Wrote {$config->outputDir}/index.html");
+        return Command::SUCCESS;
+    }
+};
+
+$app = new Application('gen-ehi', '0.1.0');
+$app->add($command);
+$name = $command->getName();
+if ($name === null) {
+    throw new RuntimeException('Command name not set');
+}
+$app->setDefaultCommand($name, true);
+$app->run();

--- a/tools/release-docs/src/Cli/Options.php
+++ b/tools/release-docs/src/Cli/Options.php
@@ -33,4 +33,26 @@ final class Options
 
         return $value;
     }
+
+    /**
+     * Fetch an optional string option.
+     *
+     * Returns null when the option is absent; throws when it is present but
+     * empty, so an explicit `--opt=` is a usage error rather than a silent
+     * fall-through to the default.
+     *
+     * @return non-empty-string|null
+     */
+    public static function optionalString(InputInterface $input, string $name): ?string
+    {
+        $value = $input->getOption($name);
+        if ($value === null) {
+            return null;
+        }
+        if (!is_string($value) || $value === '') {
+            throw new RuntimeException("--$name must not be empty");
+        }
+
+        return $value;
+    }
 }

--- a/tools/release-docs/src/EhiSchemaGenerator.php
+++ b/tools/release-docs/src/EhiSchemaGenerator.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Regenerate the EHI / ONC (b)(10) SchemaSpy schema documentation.
+ *
+ * Reads the in-scope table set from openemr's `b10-tables.yml`, builds the
+ * SchemaSpy include filter, and runs the bundled schemaspy.jar against a
+ * freshly-loaded schema. The table set is read from the openemr checkout so it
+ * always matches the schema of the release being documented.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs;
+
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+
+final class EhiSchemaGenerator
+{
+    private const string DB_TYPE = 'mariadb';
+
+    public function generate(EhiSchemaSpyConfig $config): void
+    {
+        $tables = $this->parseTables($this->readFile($config->tablesFile));
+        $command = $this->buildCommand($config, $this->includeRegex($tables));
+
+        $process = new Process($command);
+        $process->setTimeout(null);
+        $process->mustRun();
+
+        $indexHtml = $config->outputDir . '/index.html';
+        if (!is_file($indexHtml)) {
+            throw new RuntimeException("SchemaSpy did not produce $indexHtml");
+        }
+    }
+
+    /**
+     * Flatten the grouped (b)(10) table set into a sorted, de-duplicated list.
+     *
+     * @return list<non-empty-string>
+     */
+    public function parseTables(string $yamlContent): array
+    {
+        $parsed = Yaml::parse($yamlContent);
+        if (!is_array($parsed) || !isset($parsed['groups']) || !is_array($parsed['groups'])) {
+            throw new RuntimeException('b10-tables.yml must contain a top-level "groups" mapping');
+        }
+
+        $tables = [];
+        foreach ($parsed['groups'] as $members) {
+            if (!is_array($members)) {
+                throw new RuntimeException('Each group in b10-tables.yml must be a list of table names');
+            }
+            foreach ($members as $table) {
+                if (!is_string($table) || $table === '') {
+                    throw new RuntimeException('Table names in b10-tables.yml must be non-empty strings');
+                }
+                $tables[] = $table;
+            }
+        }
+
+        $unique = array_values(array_unique($tables));
+        sort($unique);
+
+        return $unique;
+    }
+
+    /**
+     * SchemaSpy include filter — a regex alternation of the in-scope tables.
+     *
+     * @param list<non-empty-string> $tables
+     */
+    public function includeRegex(array $tables): string
+    {
+        if ($tables === []) {
+            throw new RuntimeException('Cannot build an include filter from an empty table list');
+        }
+
+        return '(' . implode('|', $tables) . ')';
+    }
+
+    /**
+     * Assemble the SchemaSpy java argv. Pure (no IO), so it is unit-testable.
+     *
+     * @return list<string>
+     */
+    public function buildCommand(EhiSchemaSpyConfig $config, string $includeRegex): array
+    {
+        return [
+            'java',
+            '-jar', $config->jar,
+            '-t', self::DB_TYPE,
+            '-host', $config->dbHost,
+            '-port', (string) $config->dbPort,
+            '-db', $config->dbName,
+            '-u', $config->dbUser,
+            '-p', $config->dbPassword,
+            '-s', $config->dbSchema,
+            '-dp', $config->connectorJar,
+            '-o', $config->outputDir,
+            '-i', $includeRegex,
+            '-meta', $config->metaPath,
+            '-template', $config->templateDir,
+            '-vizjs',
+            '-norows',
+            '-noimplied',
+            '-nopages',
+        ];
+    }
+
+    private function readFile(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new RuntimeException("Could not read $path");
+        }
+
+        return $contents;
+    }
+}

--- a/tools/release-docs/src/EhiSchemaSpyConfig.php
+++ b/tools/release-docs/src/EhiSchemaSpyConfig.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Resolved inputs for one EHI / ONC (b)(10) SchemaSpy generation run.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs;
+
+final readonly class EhiSchemaSpyConfig
+{
+    public function __construct(
+        public string $tablesFile,
+        public string $jar,
+        public string $connectorJar,
+        public string $metaPath,
+        public string $templateDir,
+        public string $outputDir,
+        public string $dbHost,
+        public int $dbPort,
+        public string $dbName,
+        public string $dbUser,
+        public string $dbPassword,
+        public string $dbSchema,
+    ) {
+    }
+
+    /**
+     * Derive the SchemaSpy asset paths from an openemr/openemr checkout.
+     *
+     * The (b)(10) table set and the bundled schemaspy.jar, connector, schema
+     * metadata, and mustache template all live in the openemr repo, versioned
+     * with the schema. `tablesFile` / `schemaspyDir` overrides exist for the
+     * retroactive path, where assets come from openemr master while the schema
+     * itself is loaded from an older tagged release.
+     */
+    public static function fromOpenemrCheckout(
+        string $openemrCheckout,
+        string $outputDir,
+        string $dbHost,
+        int $dbPort,
+        string $dbName,
+        string $dbUser,
+        string $dbPassword,
+        string $dbSchema,
+        ?string $tablesFile = null,
+        ?string $schemaspyDir = null,
+    ): self {
+        $checkout = rtrim($openemrCheckout, '/');
+        $schemaspy = $schemaspyDir ?? "$checkout/Documentation/EHI_Export/schemaspy";
+        $jars = "$schemaspy/jars";
+
+        return new self(
+            tablesFile: $tablesFile ?? "$checkout/Documentation/EHI_Export/b10-tables.yml",
+            jar: "$jars/schemaspy.jar",
+            connectorJar: "$jars/mariadb-java-client-3.4.1.jar",
+            metaPath: "$schemaspy/schemas/",
+            templateDir: "$schemaspy/layout/",
+            outputDir: rtrim($outputDir, '/'),
+            dbHost: $dbHost,
+            dbPort: $dbPort,
+            dbName: $dbName,
+            dbUser: $dbUser,
+            dbPassword: $dbPassword,
+            dbSchema: $dbSchema,
+        );
+    }
+}

--- a/tools/release-docs/tests/EhiSchemaGeneratorTest.php
+++ b/tools/release-docs/tests/EhiSchemaGeneratorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs\Tests;
+
+use OpenEMR\ReleaseDocs\EhiSchemaGenerator;
+use OpenEMR\ReleaseDocs\EhiSchemaSpyConfig;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class EhiSchemaGeneratorTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures/ehi';
+
+    public function testParseTablesFlattensSortsAndDeduplicates(): void
+    {
+        $tables = (new EhiSchemaGenerator())->parseTables(self::loadFixture('b10-tables.yml'));
+
+        self::assertSame(['apple', 'banana', 'mango', 'zebra'], $tables);
+    }
+
+    public function testParseTablesRejectsMissingGroups(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('groups');
+
+        (new EhiSchemaGenerator())->parseTables("tables:\n  - foo\n");
+    }
+
+    public function testParseTablesRejectsNonListGroup(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new EhiSchemaGenerator())->parseTables("groups:\n  alpha: foo\n");
+    }
+
+    public function testParseTablesRejectsEmptyTableName(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new EhiSchemaGenerator())->parseTables("groups:\n  alpha:\n    - ''\n");
+    }
+
+    public function testIncludeRegexBuildsAlternation(): void
+    {
+        $regex = (new EhiSchemaGenerator())->includeRegex(['apple', 'banana', 'mango']);
+
+        self::assertSame('(apple|banana|mango)', $regex);
+    }
+
+    public function testIncludeRegexRejectsEmptyList(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new EhiSchemaGenerator())->includeRegex([]);
+    }
+
+    public function testBuildCommandContainsSchemaSpyFlags(): void
+    {
+        $command = (new EhiSchemaGenerator())->buildCommand($this->config(), '(apple|banana)');
+
+        self::assertContainsAdjacent($command, '-i', '(apple|banana)');
+        self::assertContainsAdjacent($command, '-meta', '/checkout/schemaspy/schemas/');
+        self::assertContainsAdjacent($command, '-template', '/checkout/schemaspy/layout/');
+        self::assertContains('-vizjs', $command);
+        self::assertContains('-norows', $command);
+        self::assertContains('-noimplied', $command);
+        self::assertContains('-nopages', $command);
+    }
+
+    /**
+     * Assert that `$needle` appears in `$haystack` immediately followed by
+     * `$value` — the argv pairing SchemaSpy expects for `-flag value`.
+     *
+     * @param list<string> $haystack
+     */
+    private static function assertContainsAdjacent(array $haystack, string $needle, string $value): void
+    {
+        $index = array_search($needle, $haystack, true);
+        self::assertIsInt($index, "argv is missing $needle");
+        self::assertSame($value, $haystack[$index + 1] ?? null, "$needle should be followed by $value");
+    }
+
+    private function config(): EhiSchemaSpyConfig
+    {
+        return EhiSchemaSpyConfig::fromOpenemrCheckout(
+            openemrCheckout: '/checkout',
+            outputDir: '/out',
+            dbHost: '127.0.0.1',
+            dbPort: 3306,
+            dbName: 'openemr',
+            dbUser: 'openemr',
+            dbPassword: 'openemr',
+            dbSchema: 'openemr',
+            schemaspyDir: '/checkout/schemaspy',
+        );
+    }
+
+    private static function loadFixture(string $name): string
+    {
+        $contents = file_get_contents(self::FIXTURE_DIR . '/' . $name);
+        if ($contents === false) {
+            throw new RuntimeException("Fixture not readable: $name");
+        }
+
+        return $contents;
+    }
+}

--- a/tools/release-docs/tests/fixtures/ehi/b10-tables.yml
+++ b/tools/release-docs/tests/fixtures/ehi/b10-tables.yml
@@ -1,0 +1,11 @@
+# Synthetic fixture for EhiSchemaGeneratorTest — NOT openemr's real table set.
+# Exercises grouping, cross-group duplication, and unsorted input so the
+# flatten/sort/dedupe logic is observable. Keep small and self-contained.
+groups:
+  alpha:
+    - zebra
+    - mango
+    - apple
+  beta:
+    - mango
+    - banana


### PR DESCRIPTION
## Summary
- Regenerate the ONC (b)(10) EHI SchemaSpy DB docs fresh in CI and publish them to the Hugo site at `/documentation/<version>/b10/`, with the whole subtree git-lfs-tracked.
- New `tools/release-docs` generator (`gen-ehi.php` + `EhiSchemaGenerator`/`EhiSchemaSpyConfig`): reads the in-scope table set from openemr's `b10-tables.yml` at the tagged sha, builds the SchemaSpy include filter, and runs the bundled `schemaspy.jar` against a freshly-loaded schema.
- Wired into `release-docs.yml` (mariadb:11 service, resolve/fallback-checkout/setup-java/generate steps, gated on `openemr-tag` || `workflow_dispatch`), `release-docs-ci.yml` (`gen-ehi-smoke` job), and `deploy-pages.yml` (`lfs: true`).

## Why
The (b)(10) docs previously reached users through no automated path — the tree committed in openemr is `export-ignore`d. This regenerates them per FINAL tag from the schema being documented. Companion: openemr/openemr#12397 (moves the table set into `b10-tables.yml`); merge that first so the live-tag path finds the file at the tagged sha.

## Notes
- **Cadence:** regen runs on `openemr-tag` and manual `workflow_dispatch` only.
- **8.1.0 retroactive:** published via `workflow_dispatch` after merge (master-fallback supplies assets while the schema loads from the 8.1.0 tag's `sql/database.sql`).
- **Pages size:** the b10 tree is ~107MB/release; GitHub Pages' ~1GB soft cap ≈ 9 releases — prune older versions later.
- **Idle service:** the always-on `mariadb:11` service idles (~10–20s) on DRAFT dispatches since job services can't be made conditional. Accepted to match the locked plan.

## Test plan
- [ ] `composer check` green (phpcs, phpstan max+strict, phpunit incl. EHI generator tests).
- [ ] `gen-ehi-smoke` CI job exercises the real `schemaspy.jar` run.
- [x] Verified locally via docker compose (`mariadb:11` + php-8.5/jre container running the real `gen-ehi.php`): `schemaspy.jar` emitted a complete doc tree (`index.html` + per-table pages, diagrams, columns, constraints) from the 140-table set against a fresh `sql/database.sql` load.