### PR TITLE
ci: purge Cloudflare cache after Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -127,3 +127,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+      # Best-effort: GitHub Pages serves www.open-emr.org via Cloudflare,
+      # which caches aggressively. Purge so the new deploy is visible
+      # without waiting for TTL expiry. Never fails the deploy.
+      - name: Purge Cloudflare cache
+        if: success()
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          if [[ -z "$CLOUDFLARE_API_TOKEN" || -z "$CLOUDFLARE_ZONE_ID" ]]; then
+            echo "Cloudflare secrets not set; skipping cache purge."
+            exit 0
+          fi
+          curl --fail --silent --show-error \
+            -X POST "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/purge_cache" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'


### PR DESCRIPTION
## Summary
- `www.open-emr.org` is fronted by Cloudflare, which caches aggressively, so a fresh master deploy isn't visible until the cache TTL expires.
- Add a best-effort Cloudflare cache purge step to the `deploy` job, right after `actions/deploy-pages`.

## Behavior
- Runs only on a successful deploy (`if: success()`), so never on PRs.
- `continue-on-error: true` — a purge failure never fails the deploy.
- Skips cleanly with a log line if `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` secrets are absent.
- Uses `purge_everything`, appropriate for a full-site rebuild.

Requires repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` (already configured).