### PR TITLE
fix(downloads): link generated install page from downloads page

### DIFF
--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -32,6 +32,15 @@
 
                     {{ $dl := .entry.downloads | default dict }}
 
+                    {{/* Dispatch-driven releases (those with a branch) carry a
+                         generated /installation/<version>/ page. Derive the link
+                         here rather than storing a derivable path in the manifest,
+                         mirroring how archive_urls are derived at render time. */}}
+                    {{ $installUrl := "" }}
+                    {{ with .entry.branch }}
+                        {{ $installUrl = printf "/installation/%s/" $latest.version }}
+                    {{ end }}
+
                     <h3>Docker (recommended)</h3>
                     <p>The official OpenEMR Docker image is the recommended way to run OpenEMR.</p>
                     <ul>
@@ -51,9 +60,9 @@
                         {{ end }}
                         {{ with $dl.linux }}
                             {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
-                            {{ with .install_url }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
+                        {{ with (or $dl.linux.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
                     </ul>
 
                     <h3>Windows</h3>
@@ -65,9 +74,9 @@
                         {{ end }}
                         {{ with $dl.windows }}
                             {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
-                            {{ with .install_url }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
+                        {{ with (or $dl.windows.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
                     </ul>
 
                     <h3>What's in this release</h3>


### PR DESCRIPTION
## Summary

The release-docs generator writes `content/installation/<version>.md` on every dispatch (`gen-install-page`), but the manifest writer (`ReleasesManifest`) never populates `downloads.*.install_url`. The downloads page only rendered an "Installation Instructions" link when that field existed, so the generated install page was an **orphan** — reachable only by typing the URL directly.

This is a structural gap, not a one-off: every dispatch-driven release produces an unreachable install page. Surfaced while reviewing the 8.1.0 release-docs PR (#142), where `/installation/8.1.0/` had no in-site link.

## Fix

Derive `/installation/<version>/` at render time in `downloads.html` for dispatch-driven entries (those carrying a `branch`), mirroring how `archive_urls` are already derived rather than stored in the manifest. An explicit `downloads.*.install_url` still takes precedence if set. Historical entries (no `branch`) are unaffected.

Template-only — no schema, data, or PHP generator change. One change fixes 8.1.0 and all future releases.

## Test plan

- [x] `hugo` builds clean (123 pages)
- [x] `/downloads/` renders `/installation/8.1.0/` under Linux and Windows; target resolves (HTTP 200)
- [x] Historical (SourceForge-era) entries get no spurious link
- [x] release-docs PHPUnit suite green (79 tests)