### PR TITLE
feat(ci): publish branch and fork-PR website previews

### DIFF
--- a/.github/workflows/preview-branch.yml
+++ b/.github/workflows/preview-branch.yml
@@ -1,0 +1,102 @@
+# Publishes a preview of any non-master org branch to the previews repo
+# so changes are viewable before merge. Each branch lands in its own
+# `branch-<slug>/` subfolder under
+# https://openemr.github.io/website-openemr-previews/.
+#
+# Trusted context: this only fires on pushes to branches in this repo
+# (forks can't push here), so it may hold the app token and build with
+# the real `npm ci` step. Fork PRs are handled separately by
+# preview-pr-build.yml / preview-pr-publish.yml.
+#
+# Production (deploy-pages.yml -> openemr.github.io/website-openemr/ +
+# Cloudflare) is never touched.
+name: preview-branch
+
+on:
+  push:
+    branches-ignore: [master]
+    paths:
+      - 'content/**'
+      - 'layouts/**'
+      - 'data/**'
+      - 'static/**'
+      - 'archetypes/**'
+      - 'themes/**'
+      - 'config.yaml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/preview-branch.yml'
+
+permissions:
+  contents: read
+
+# Serialize per-branch so two quick pushes don't race on the same
+# destination folder; supersede in-flight builds for the same branch.
+concurrency:
+  group: preview-branch-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HUGO_VERSION: '0.150.0'
+  NODE_VERSION: '24'
+  PREVIEWS_REPO: openemr/website-openemr-previews
+  PREVIEWS_BASE: https://openemr.github.io/website-openemr-previews
+
+jobs:
+  preview:
+    name: build and publish branch preview
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      # branch name -> URL/path-safe slug: every non-alphanumeric run
+      # collapses to one '-' (tr -cs squeezes), with edge dashes trimmed.
+      # Must match the cleanup workflow exactly so the publish and remove
+      # paths agree.
+      - name: Compute slug
+        id: slug
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          slug="$(printf '%s' "$BRANCH" | tr -cs 'A-Za-z0-9' '-')"
+          slug="${slug#-}"
+          slug="${slug%-}"
+          if [[ -z "$slug" ]]; then
+            echo "Branch '$BRANCH' produced an empty slug." >&2
+            exit 1
+          fi
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Install theme dependencies
+        working-directory: ./themes/openemr
+        run: npm ci
+      - name: Build site
+        env:
+          BASE_URL: ${{ env.PREVIEWS_BASE }}/branch-${{ steps.slug.outputs.slug }}/
+        run: hugo --gc --minify --baseURL "$BASE_URL"
+      - name: Mint App token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            website-openemr-previews
+      - name: Publish to previews repo
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ steps.token.outputs.token }}
+          external_repository: ${{ env.PREVIEWS_REPO }}
+          publish_branch: gh-pages
+          publish_dir: ./public
+          destination_dir: branch-${{ steps.slug.outputs.slug }}
+          keep_files: true
+          commit_message: "preview: branch ${{ github.ref_name }} @ ${{ github.sha }}"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,87 @@
+# Removes preview folders from the previews repo when their source goes
+# away: an org branch being deleted (covers internal-PR branches deleted
+# on merge) or a fork PR being closed.
+#
+# Both triggers run in the BASE repo context. The `delete` event carries
+# only a branch name; `pull_request_target [closed]` carries only a PR
+# number. Neither checks out PR code — the job just `git rm`s a folder
+# whose name it derives from those trusted, structured fields — so
+# `pull_request_target` is safe here.
+name: preview-cleanup
+
+on:
+  delete:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-cleanup-${{ github.event.ref || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  PREVIEWS_REPO: openemr/website-openemr-previews
+
+jobs:
+  cleanup:
+    name: remove preview folder
+    # delete: only branches (not tags). pull_request_target: only fork
+    # PRs, since org-branch previews are removed by the branch delete.
+    if: >-
+      (github.event_name == 'delete' && github.event.ref_type == 'branch') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve preview folder
+        id: folder
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BRANCH: ${{ github.event.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$EVENT_NAME" == 'delete' ]]; then
+            # Keep this slug logic identical to preview-branch.yml.
+            slug="$(printf '%s' "$BRANCH" | tr -cs 'A-Za-z0-9' '-')"
+            slug="${slug#-}"
+            slug="${slug%-}"
+            if [[ -z "$slug" ]]; then
+              echo "Branch '$BRANCH' produced an empty slug; nothing to remove." >&2
+              exit 0
+            fi
+            echo "dir=branch-$slug" >> "$GITHUB_OUTPUT"
+          else
+            if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "PR number '$PR_NUMBER' is not an integer." >&2
+              exit 1
+            fi
+            echo "dir=pr-$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Mint App token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            website-openemr-previews
+      - name: Remove folder from gh-pages
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PREVIEW_DIR: ${{ steps.folder.outputs.dir }}
+        run: |
+          tmp="$(mktemp -d)"
+          git clone --depth 1 --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${PREVIEWS_REPO}.git" "$tmp"
+          cd "$tmp"
+          if [[ ! -d "$PREVIEW_DIR" ]]; then
+            echo "No preview folder '$PREVIEW_DIR'; nothing to remove."
+            exit 0
+          fi
+          git rm -r --quiet "$PREVIEW_DIR"
+          git -c user.name='openemr-release[bot]' \
+              -c user.email='openemr-release[bot]@users.noreply.github.com' \
+              commit -m "preview: remove $PREVIEW_DIR"
+          git push origin gh-pages

--- a/.github/workflows/preview-pr-build.yml
+++ b/.github/workflows/preview-pr-build.yml
@@ -1,0 +1,78 @@
+# Stage 1 of the fork-PR preview: build only, no secrets.
+#
+# Fork PRs run untrusted code (the PR's own `npm ci` install scripts,
+# Hugo config, etc.), so this uses `pull_request` — NOT
+# `pull_request_target` — which checks out the fork head with a
+# read-only GITHUB_TOKEN and no access to repo secrets. The built site
+# and the PR number are handed to the trusted publish stage
+# (preview-pr-publish.yml) via an artifact + workflow_run.
+#
+# Org-branch PRs already get previews from preview-branch.yml on push,
+# so this is gated to forks only to avoid double-publishing.
+name: preview-pr-build
+
+on:
+  pull_request:
+    paths:
+      - 'content/**'
+      - 'layouts/**'
+      - 'data/**'
+      - 'static/**'
+      - 'archetypes/**'
+      - 'themes/**'
+      - 'config.yaml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/preview-pr-build.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  HUGO_VERSION: '0.150.0'
+  NODE_VERSION: '24'
+  PREVIEWS_BASE: https://openemr.github.io/website-openemr-previews
+
+jobs:
+  build:
+    name: build fork PR preview
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install theme dependencies
+        working-directory: ./themes/openemr
+        run: npm ci
+      - name: Build site
+        env:
+          BASE_URL: ${{ env.PREVIEWS_BASE }}/pr-${{ github.event.pull_request.number }}/
+        run: hugo --gc --minify --baseURL "$BASE_URL"
+      # The publish stage runs in base context and can't trust the PR
+      # number from the workflow_run event (empty for forks), so persist
+      # it as a sibling of the built site — outside ./public so it is
+      # never published into the preview folder.
+      - name: Record PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > ./pr-number.txt
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview
+          path: |
+            public
+            pr-number.txt
+          if-no-files-found: error

--- a/.github/workflows/preview-pr-publish.yml
+++ b/.github/workflows/preview-pr-publish.yml
@@ -1,0 +1,77 @@
+# Stage 2 of the fork-PR preview: publish the artifact built by
+# preview-pr-build.yml.
+#
+# `workflow_run` runs in the BASE repo context — it has secrets and a
+# write token — but it must never check out or execute the fork's PR
+# code. It only consumes the already-built `public/` artifact and a
+# PR number, both produced by the untrusted build stage. The PR number
+# is re-validated as an integer here before it touches any path, URL, or
+# API call, so a malicious artifact can't escape the `pr-<N>/` folder or
+# comment on an arbitrary issue.
+name: preview-pr-publish
+
+on:
+  workflow_run:
+    workflows: [preview-pr-build]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  PREVIEWS_REPO: openemr/website-openemr-previews
+  PREVIEWS_BASE: https://openemr.github.io/website-openemr-previews
+
+jobs:
+  publish:
+    name: publish fork PR preview
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-preview
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate PR number
+        id: pr
+        run: |
+          number="$(cat artifact/pr-number.txt)"
+          if [[ ! "$number" =~ ^[0-9]+$ ]]; then
+            echo "Refusing to publish: PR number '$number' is not an integer." >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+      - name: Mint App token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            website-openemr-previews
+      - name: Publish to previews repo
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ steps.token.outputs.token }}
+          external_repository: ${{ env.PREVIEWS_REPO }}
+          publish_branch: gh-pages
+          publish_dir: ./artifact/public
+          destination_dir: pr-${{ steps.pr.outputs.number }}
+          keep_files: true
+          commit_message: "preview: PR #${{ steps.pr.outputs.number }}"
+      - name: Comment preview link
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: website-preview
+          message: |
+            ## Website preview
+
+            Built from this PR: ${{ env.PREVIEWS_BASE }}/pr-${{ steps.pr.outputs.number }}/
+
+            Updates on each push. Removed when the PR is closed.


### PR DESCRIPTION
## Summary

Implements #138 — publish viewable previews of website changes **before merge**, without touching the production deploy.

- Org branches → `branch-<slug>/`, fork PRs → `pr-<N>/`, served from a separate `openemr/website-openemr-previews` repo at `https://openemr.github.io/website-openemr-previews/<folder>/`.
- Production (`deploy-pages.yml` → `openemr.github.io/website-openemr/` + Cloudflare) is **not modified** — a repo has only one Pages source, so previews live in their own repo.

## Workflows added

- **`preview-branch.yml`** — `on: push` (non-master, content paths). Trusted: builds with `--baseURL .../branch-<slug>/`, mints a least-privilege app token, pushes to the previews repo (`keep_files: true`).
- **`preview-pr-build.yml`** — `on: pull_request`, fork PRs only. Uses `pull_request` (not `pull_request_target`) so untrusted fork code runs with **no secrets**; uploads built `public/` + PR number as an artifact.
- **`preview-pr-publish.yml`** — `on: workflow_run` (completed, success). Runs in base context, downloads the artifact, **re-validates the PR number as an integer** before any path/URL use, publishes `pr-<N>/`, and posts a sticky comment linking the preview.
- **`preview-cleanup.yml`** — `on: delete` removes `branch-<slug>/` (also covers internal-PR branches deleted on merge); `on: pull_request_target [closed]` removes `pr-<N>/`. No PR code is checked out, so `pull_request_target` is safe.

Slug derivation (`tr -cs 'A-Za-z0-9' '-'` + edge-dash trim) is inlined in the two workflows that need it, kept identical via matching comments — no new language added to the repo.

## ⚠️ Requires out-of-band org setup before this works (needs an org owner)

1. Create public repo `openemr/website-openemr-previews`.
2. Seed a `gh-pages` branch with a placeholder `index.html` + `robots.txt` (`Disallow: /`).
3. Repo Settings → Pages: source = branch `gh-pages`, path `/`.
4. Add `website-openemr-previews` to the existing **RELEASE GitHub App** installation's repo selection.

## Test plan

- [x] After org setup, `openemr.github.io/website-openemr-previews/` serves the placeholder.
- [x] `preview-branch.yml` runs green on this branch's push and publishes `branch-feat-pr-previews/`. Verified live: homepage, main CSS, Cooper Hewitt font CSS, blog index, a blog post, and the demo page all return 200, and internal nav links + the hashed stylesheet are rewritten to the `.../branch-feat-pr-previews/` base path (no prod-path leakage).
- [ ] Branch-delete cleanup, fork-PR build→publish, and PR-close cleanup can only be exercised **after merge**: `delete`, `workflow_run`, and `pull_request_target` events run the workflow from the default branch, so these three flows are untestable from the PR branch. To verify post-merge: push+delete a throwaway org branch (folder appears then 404s); open+close a fork PR (build artifact → `pr-<N>/` published + sticky comment → folder 404s on close).
- [x] `actionlint` failure is the pre-existing `create-github-app-token@v3` stale-metadata false positive (`client-id`/`app-id`) — the same check is red on `master` and is unrelated to this PR.
