### PR TITLE
Drop /downloads/ compatibility matrix in favor of release notes

### DIFF
--- a/data/releases.json
+++ b/data/releases.json
@@ -132,12 +132,6 @@
         "branch": "rel-800",
         "sha": "b91b73600327acb46252b9fce7d04467eea126fd",
         "released_at": "2026-02-13",
-        "compatibility": {
-            "php":     { "min": "8.2",  "max": "8.5"  },
-            "mariadb": { "min": "10.6", "max": "11.8" },
-            "mysql":   { "min": "5.7",  "max": "8.4"  },
-            "recommended_db": "MariaDB"
-        },
         "downloads": {
             "docker": {
                 "install_url": "https://community.open-emr.org/t/openemr-official-docker-has-been-released/9084"

--- a/data/releases.schema.json
+++ b/data/releases.schema.json
@@ -5,17 +5,6 @@
     "description": "Per-version release status, consumed by the release-status Hugo shortcode and the /releases/ and /downloads/ pages, and written by the release-docs workflow on inbound dispatches from openemr/openemr. Historical entries (versions that predate the rel-* branch and dispatch automation) carry only status, released_at, and archive_urls; the dispatch writer never touches them.",
     "type": "object",
     "additionalProperties": false,
-    "$defs": {
-        "versionRange": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["min", "max"],
-            "properties": {
-                "min": { "type": "string" },
-                "max": { "type": "string" }
-            }
-        }
-    },
     "patternProperties": {
         "^\\d+\\.\\d+\\.\\d+$": {
             "type": "object",
@@ -49,17 +38,6 @@
                     "properties": {
                         "tarball": { "type": "string", "format": "uri" },
                         "zip": { "type": "string", "format": "uri" }
-                    }
-                },
-                "compatibility": {
-                    "description": "Supported runtime versions for this release, surfaced on the /downloads/ page. Each component carries an inclusive min/max version range. recommended_db (when set) names the database the project recommends when both MariaDB and MySQL are supported.",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "php":     { "$ref": "#/$defs/versionRange" },
-                        "mariadb": { "$ref": "#/$defs/versionRange" },
-                        "mysql":   { "$ref": "#/$defs/versionRange" },
-                        "recommended_db": { "enum": ["MariaDB", "MySQL"] }
                     }
                 },
                 "downloads": {

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -20,13 +20,10 @@
                     <h2>Stable production release &mdash; version {{ .version }}</h2>
                     <p>Released {{ .entry.released_at }}.</p>
 
-                    {{ with .entry.compatibility }}
+                    {{ if not .entry.archive_urls }}
                         <p>
-                            Compatibility:
-                            {{ with .php }}PHP {{ .min }}&ndash;{{ .max }}{{ end }}{{ if and .php (or .mariadb .mysql) }}, {{ end }}
-                            {{ with .mariadb }}MariaDB {{ .min }}&ndash;{{ .max }}{{ end }}{{ if and .mariadb .mysql }}, {{ end }}
-                            {{ with .mysql }}MySQL {{ .min }}&ndash;{{ .max }}{{ end }}.
-                            {{ with .recommended_db }}{{ . }} is recommended.{{ end }}
+                            For supported PHP and database versions, see the
+                            <a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">release notes</a>.
                         </p>
                     {{ end }}
 

--- a/tools/release-docs/src/Manifest/ReleasesManifest.php
+++ b/tools/release-docs/src/Manifest/ReleasesManifest.php
@@ -152,8 +152,7 @@ final class ReleasesManifest
      * Normalize a decoded manifest entry. Only enforces that keys are strings
      * and leaf values are scalar (string) or null; the JSON schema validator
      * is the authoritative check on structural shape, so nested objects
-     * (compatibility.php = {min, max}, downloads.docker = {install_url}, etc.)
-     * pass through unchanged.
+     * (downloads.docker = {install_url}, etc.) pass through unchanged.
      *
      * @param array<int|string, mixed> $entry
      * @return array<string, mixed>

--- a/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
+++ b/tools/release-docs/tests/Manifest/ReleasesManifestApplyTest.php
@@ -223,7 +223,7 @@ final class ReleasesManifestApplyTest extends TestCase
         );
     }
 
-    public function testEntryWithNestedCompatibilityAndDownloadsLoads(): void
+    public function testEntryWithNestedDownloadsLoads(): void
     {
         $this->seed([
             '8.0.0' => [
@@ -231,11 +231,6 @@ final class ReleasesManifestApplyTest extends TestCase
                 'branch' => 'rel-800',
                 'sha' => 'b91b73600327acb46252b9fce7d04467eea126fd',
                 'released_at' => '2026-02-13',
-                'compatibility' => [
-                    'php' => ['min' => '8.2', 'max' => '8.5'],
-                    'mariadb' => ['min' => '10.6', 'max' => '11.8'],
-                    'recommended_db' => 'MariaDB',
-                ],
                 'downloads' => [
                     'docker' => ['install_url' => 'https://example.invalid/docker'],
                 ],
@@ -257,11 +252,6 @@ final class ReleasesManifestApplyTest extends TestCase
                 'branch' => 'rel-800',
                 'sha' => 'b91b73600327acb46252b9fce7d04467eea126fd',
                 'released_at' => '2026-02-13',
-                'compatibility' => [
-                    'php' => ['min' => '8.2', 'max' => '8.5'],
-                    'mariadb' => ['min' => '10.6', 'max' => '11.8'],
-                    'recommended_db' => 'MariaDB',
-                ],
                 'downloads' => [
                     'docker' => ['install_url' => 'https://example.invalid/docker'],
                 ],


### PR DESCRIPTION
## Summary
- Removes the hand-authored `compatibility` object (PHP/MariaDB/MySQL min–max ranges + `recommended_db`) from `data/releases.json`, its definition in `data/releases.schema.json`, and the rendering in `layouts/section/downloads.html`.
- The `/downloads/` page now points readers to the GitHub **release notes** for supported PHP/database versions, instead of duplicating a matrix that was only ever filled in by hand for 8.0.0 (8.1.0 already had none).

## Why
Compatibility info is now stated upstream in the openemr release notes — minimum supported versions plus a link to the tested CI matrix (openemr/openemr-devops#793). That makes the website's hand-maintained matrix redundant and prone to drift. This closes the loop on the abandoned automation approach (website-openemr#146, openemr/openemr#12421, both closed).

## Changes
- `data/releases.json` — drop the `compatibility` block from the 8.0.0 entry.
- `data/releases.schema.json` — remove the `compatibility` property and the now-unused `versionRange` `$def`.
- `layouts/section/downloads.html` — replace the compatibility paragraph with a link to the release notes (shown for dispatch-driven releases, which have GitHub release notes).
- `tools/release-docs/` — drop `compatibility` from a pass-through test fixture and a docblock example (the manifest writer never produced it).

## Test plan
- [x] `composer check` in `tools/release-docs` green: phpcs, phpstan, 79 tests
- [x] `releases.json` validates against the updated schema
- [x] `hugo` build succeeds; rendered `/downloads/` shows the release-notes link and no longer renders the old "Compatibility: PHP …" line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to GitHub release notes for releases without archive URLs.

* **Chores**
  * Removed system requirement compatibility information from the releases manifest and downloads page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->