### PR TITLE
fix(ci): retry preview gh-pages pushes to survive concurrent races

### DIFF
--- a/.github/actions/previews-commit/action.yml
+++ b/.github/actions/previews-commit/action.yml
@@ -63,6 +63,11 @@ runs:
           src="$(cd "$SOURCE_DIR" && pwd)"
         fi
 
+        if [[ ! "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+          echo "Input 'attempts' must be a positive integer, got '$MAX_ATTEMPTS'." >&2
+          exit 1
+        fi
+
         attempt=1
         while (( attempt <= MAX_ATTEMPTS )); do
           tmp="$(mktemp -d)"

--- a/.github/actions/previews-commit/action.yml
+++ b/.github/actions/previews-commit/action.yml
@@ -1,0 +1,107 @@
+# Commits a single preview folder to the previews repo's gh-pages branch
+# and pushes, retrying on a rejected push.
+#
+# Every preview workflow (branch publish, fork-PR publish, cleanup) pushes
+# to the same gh-pages ref but only ever touches its own folder. Two that
+# overlap in time race: one clones the tip, the other pushes first, and the
+# loser's push is rejected for being non-fast-forward — silently dropping a
+# preview (and its PR comment). Re-cloning the fresh tip and replaying the
+# same folder mutation is idempotent, so retrying converges.
+#
+# This runs in the BASE repo context with a write token but never checks
+# out or executes PR code — it only adds/removes a folder whose name the
+# caller derives from trusted, structured fields.
+name: Commit a preview folder
+description: Publish or remove one preview folder on the previews gh-pages branch, retrying on push rejection.
+
+inputs:
+  token:
+    description: Token with write access to the previews repo.
+    required: true
+  repo:
+    description: owner/name of the previews repo.
+    required: true
+  dir:
+    description: Preview folder to write or remove (e.g. branch-foo, pr-150).
+    required: true
+  source:
+    description: >-
+      Directory whose contents replace `dir`. When empty, `dir` is removed
+      instead (cleanup mode).
+    required: false
+    default: ''
+  message:
+    description: Commit message.
+    required: true
+  attempts:
+    description: Max push attempts before failing.
+    required: false
+    default: '5'
+
+runs:
+  using: composite
+  steps:
+    - name: Commit and push
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PREVIEWS_REPO: ${{ inputs.repo }}
+        DEST_DIR: ${{ inputs.dir }}
+        SOURCE_DIR: ${{ inputs.source }}
+        COMMIT_MSG: ${{ inputs.message }}
+        MAX_ATTEMPTS: ${{ inputs.attempts }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$DEST_DIR" || "$DEST_DIR" == */* || "$DEST_DIR" == .* ]]; then
+          echo "Refusing to operate on suspicious folder '$DEST_DIR'." >&2
+          exit 1
+        fi
+
+        src=''
+        if [[ -n "$SOURCE_DIR" ]]; then
+          src="$(cd "$SOURCE_DIR" && pwd)"
+        fi
+
+        attempt=1
+        while (( attempt <= MAX_ATTEMPTS )); do
+          tmp="$(mktemp -d)"
+          git clone --depth 1 --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${PREVIEWS_REPO}.git" "$tmp"
+
+          if [[ -n "$src" ]]; then
+            rm -rf "${tmp:?}/${DEST_DIR}"
+            mkdir -p "$tmp/$DEST_DIR"
+            cp -a "$src/." "$tmp/$DEST_DIR/"
+          else
+            if [[ ! -d "$tmp/$DEST_DIR" ]]; then
+              echo "No preview folder '$DEST_DIR'; nothing to remove."
+              exit 0
+            fi
+            git -C "$tmp" rm -rq "$DEST_DIR"
+          fi
+
+          git -C "$tmp" add -A "$DEST_DIR"
+          if git -C "$tmp" diff --cached --quiet; then
+            echo "No changes for '$DEST_DIR'; nothing to push."
+            exit 0
+          fi
+
+          git -C "$tmp" \
+            -c user.name='openemr-release[bot]' \
+            -c user.email='openemr-release[bot]@users.noreply.github.com' \
+            commit -q -m "$COMMIT_MSG"
+
+          if git -C "$tmp" push origin gh-pages; then
+            echo "Pushed '$DEST_DIR' on attempt $attempt."
+            exit 0
+          fi
+
+          echo "Push rejected (attempt $attempt/$MAX_ATTEMPTS); refetching." >&2
+          rm -rf "$tmp"
+          sleep "$(( attempt * 3 ))"
+          (( attempt++ )) || true
+        done
+
+        echo "Failed to push '$DEST_DIR' after $MAX_ATTEMPTS attempts." >&2
+        exit 1

--- a/.github/workflows/preview-branch.yml
+++ b/.github/workflows/preview-branch.yml
@@ -98,15 +98,13 @@ jobs:
           repositories: |
             website-openemr-previews
       - name: Publish to previews repo
-        uses: peaceiris/actions-gh-pages@v4
+        uses: ./.github/actions/previews-commit
         with:
-          personal_token: ${{ steps.token.outputs.token }}
-          external_repository: ${{ env.PREVIEWS_REPO }}
-          publish_branch: gh-pages
-          publish_dir: ./public
-          destination_dir: branch-${{ steps.slug.outputs.slug }}
-          keep_files: true
-          commit_message: "preview: branch ${{ github.ref_name }} @ ${{ github.sha }}"
+          token: ${{ steps.token.outputs.token }}
+          repo: ${{ env.PREVIEWS_REPO }}
+          dir: branch-${{ steps.slug.outputs.slug }}
+          source: ./public
+          message: "preview: branch ${{ github.ref_name }} @ ${{ github.sha }}"
       # The push may land before the PR exists; then there's nothing to
       # comment on and the pull_request trigger picks it up later.
       - name: Find open PR for branch

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -34,6 +34,9 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-24.04
     steps:
+      # BASE-repo checkout for the local previews-commit action. Both
+      # triggers run in base context with only trusted, structured fields.
+      - uses: actions/checkout@v6
       - name: Resolve preview folder
         id: folder
         env:
@@ -68,20 +71,10 @@ jobs:
           repositories: |
             website-openemr-previews
       - name: Remove folder from gh-pages
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          PREVIEW_DIR: ${{ steps.folder.outputs.dir }}
-        run: |
-          tmp="$(mktemp -d)"
-          git clone --depth 1 --branch gh-pages \
-            "https://x-access-token:${GH_TOKEN}@github.com/${PREVIEWS_REPO}.git" "$tmp"
-          cd "$tmp"
-          if [[ ! -d "$PREVIEW_DIR" ]]; then
-            echo "No preview folder '$PREVIEW_DIR'; nothing to remove."
-            exit 0
-          fi
-          git rm -r --quiet "$PREVIEW_DIR"
-          git -c user.name='openemr-release[bot]' \
-              -c user.email='openemr-release[bot]@users.noreply.github.com' \
-              commit -m "preview: remove $PREVIEW_DIR"
-          git push origin gh-pages
+        if: ${{ steps.folder.outputs.dir != '' }}
+        uses: ./.github/actions/previews-commit
+        with:
+          token: ${{ steps.token.outputs.token }}
+          repo: ${{ env.PREVIEWS_REPO }}
+          dir: ${{ steps.folder.outputs.dir }}
+          message: "preview: remove ${{ steps.folder.outputs.dir }}"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -36,7 +36,10 @@ jobs:
     steps:
       # BASE-repo checkout for the local previews-commit action. Both
       # triggers run in base context with only trusted, structured fields.
+      # No git auth needed here — the action clones with its own token.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Resolve preview folder
         id: folder
         env:

--- a/.github/workflows/preview-pr-publish.yml
+++ b/.github/workflows/preview-pr-publish.yml
@@ -36,7 +36,10 @@ jobs:
       # BASE-repo checkout (default-branch HEAD) for the local
       # previews-commit action only. Runs first because checkout cleans the
       # workspace; the untrusted artifact is downloaded into ./artifact after.
+      # No git auth needed here — the action clones with its own token.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download preview artifact
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/preview-pr-publish.yml
+++ b/.github/workflows/preview-pr-publish.yml
@@ -8,6 +8,10 @@
 # is re-validated as an integer here before it touches any path, URL, or
 # API call, so a malicious artifact can't escape the `pr-<N>/` folder or
 # comment on an arbitrary issue.
+#
+# The one checkout below pulls BASE-repo code (default-branch HEAD, the
+# workflow_run default ref) solely to load the local previews-commit
+# action — never the fork's PR head.
 name: preview-pr-publish
 
 on:
@@ -29,6 +33,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
+      # BASE-repo checkout (default-branch HEAD) for the local
+      # previews-commit action only. Runs first because checkout cleans the
+      # workspace; the untrusted artifact is downloaded into ./artifact after.
+      - uses: actions/checkout@v6
       - name: Download preview artifact
         uses: actions/download-artifact@v7
         with:
@@ -55,15 +63,13 @@ jobs:
           repositories: |
             website-openemr-previews
       - name: Publish to previews repo
-        uses: peaceiris/actions-gh-pages@v4
+        uses: ./.github/actions/previews-commit
         with:
-          personal_token: ${{ steps.token.outputs.token }}
-          external_repository: ${{ env.PREVIEWS_REPO }}
-          publish_branch: gh-pages
-          publish_dir: ./artifact/public
-          destination_dir: pr-${{ steps.pr.outputs.number }}
-          keep_files: true
-          commit_message: "preview: PR #${{ steps.pr.outputs.number }}"
+          token: ${{ steps.token.outputs.token }}
+          repo: ${{ env.PREVIEWS_REPO }}
+          dir: pr-${{ steps.pr.outputs.number }}
+          source: ./artifact/public
+          message: "preview: PR #${{ steps.pr.outputs.number }}"
       - name: Comment preview link
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
## Summary
- Preview workflows (`preview-branch`, `preview-pr-publish`, `preview-cleanup`) all push to the same `gh-pages` ref of the previews repo, each writing only its own folder. When two overlap in time, the loser's push is rejected as non-fast-forward and `peaceiris/actions-gh-pages` does not retry — so a preview, and on fork PRs its preview comment, is silently dropped.
- Extract the publish/remove logic into a `previews-commit` composite action that re-clones the fresh `gh-pages` tip and **retries on push rejection**. Replaying the same single-folder mutation is idempotent, so retries converge.

## Why
On #150 the `preview-pr-build` build succeeded and uploaded its artifact, but the `preview-pr-publish` run **failed** at the publish step:

```
! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages':
  is at 3ccf9c0... but expected 04e449d...)
```

At the same instant, `preview-branch` for the `release-docs/8.1.0` org branch pushed to the same `gh-pages` branch and won the race. Because the publish step failed, the `Comment preview link` step was skipped — which is why no preview comment appeared. Nothing was wrong with the PR itself; it was collateral damage from a concurrent push.

A shared `concurrency` group was considered and rejected: GitHub keeps only one pending run per group and cancels earlier-pending ones, but these pushes target *different* folders (`pr-150` vs `branch-…`), so a cancellation would drop a legitimate preview. Fetch-rebase-retry is the correct fix for a lost-update on a shared ref.

## Changes
- `.github/actions/previews-commit/action.yml` — new composite action: clone `gh-pages`, replace (publish) or remove (cleanup) one folder, commit, push, retry up to 5× with backoff on rejection. Idempotent and folder-scoped.
- `preview-branch.yml`, `preview-pr-publish.yml` — replace the `peaceiris/actions-gh-pages` publish step with the new action.
- `preview-cleanup.yml` — replace the inline clone/rm/push (which had the same un-retried race) with the new action in remove mode.
- `preview-pr-publish.yml` / `preview-cleanup.yml` — add a BASE-repo checkout (default-branch HEAD) solely to load the local action; neither checks out fork PR code, preserving the existing `workflow_run` / `pull_request_target` security posture.

## Test plan
- [ ] actionlint passes (reviewdog, diff-scoped).
- [ ] Push to a test org branch → `preview-branch` publishes its `branch-…` folder.
- [ ] Open a fork PR → `preview-pr-publish` publishes `pr-N` and posts the sticky comment.
- [ ] Close that fork PR / delete the org branch → `preview-cleanup` removes the folder.
- [ ] Trigger two preview publishes simultaneously and confirm both land (the loser retries instead of failing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared preview publishing action that can update or remove a single preview directory in the previews site.
* **Bug Fixes**
  * Improved reliability of preview publishing and cleanup with retry/backoff when concurrent updates cause conflicts.
* **Chores**
  * Updated preview workflows to use the shared action for consistent commit/push behavior.
  * Clarified that the preview publish flow uses the already-built artifact (not fork code) and added extra PR validation for safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->