### PR TITLE
ci(claude-review): add caller for shared Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,4 +17,4 @@ jobs:
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,20 @@
+# .github/workflows/claude-review.yml
+# Drop this IDENTICAL file into all FOUR repos:
+#   openemr, openemr-devops, website-openemr, demo_farm_openemr
+#
+# It forwards events to the shared reusable workflow in openemr/openemr.
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened]        # auto-review non-bot PRs on open
+  issue_comment:
+    types: [created]       # maintainers force a review with "@claude review"
+
+jobs:
+  call-review:
+    # Reusable workflow lives in openemr/openemr. Adjust the branch ref
+    # (@master vs @main) to match that repo's default branch.
+    uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,14 @@ on:
 
 jobs:
   call-review:
+    # Reusable workflows can only reduce, not elevate, the caller job's
+    # permissions. Declare the same scopes the reusable's job needs so the
+    # effective GITHUB_TOKEN can actually post review comments.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
     # Reusable workflow lives in openemr/openemr. Adjust the branch ref
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master


### PR DESCRIPTION
Thin caller forwarding pull_request:opened and issue_comment:created events to the reusable workflow_call in openemr/openemr. Identical file also placed in openemr, openemr-devops, and demo_farm_openemr so all four repos share one review definition.

Assisted-by: Claude Code