### PR TITLE
ci(claude-review): drop pull_request trigger from caller

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,10 +6,8 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened]        # auto-review non-bot PRs on open
   issue_comment:
-    types: [created]       # maintainers force a review with "@claude review"
+    types: [created]       # maintainer comments "@claude review" on a PR
 
 jobs:
   call-review:


### PR DESCRIPTION
Reusable workflow in openemr/openemr now only responds to at-claude-review comments, so the caller no longer needs to forward pull_request opened events. Keeping both would cost a few GitHub Actions minutes per opened PR for a job that is guaranteed to skip.

Assisted-by: Claude Code