### PR TITLE
chore(coderabbit): add config, skip auto-review on bot-authored PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+reviews:
+  high_level_summary: false
+  auto_review:
+    # Skip auto-review on PRs opened by these bots. Human maintainers can
+    # still opt-in per PR by commenting "@coderabbitai review" when a bot
+    # PR warrants a look (e.g., a suspicious dependency bump).
+    ignore_usernames:
+      - dependabot[bot]
+      - openemr-release-bot[bot]


### PR DESCRIPTION
Mirrors the config landed in openemr/openemr#12706. Sets high_level_summary off and skips auto-review on dependabot and openemr-release-bot PRs. In the last 30 days those bots opened 9 of this repo's PRs. Maintainers can still request a review per PR by commenting at-coderabbitai review when a bot PR warrants a closer look.

Assisted-by: Claude Code