### PR TITLE
fix(downloads): 8.0.0 download-page cleanup + nav routing to /downloads/

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ menu:
       weight: 2
     - identifier: download
       name: Download
-      url: https://open-emr.org/wiki/index.php/OpenEMR_Downloads
+      url: /downloads
       weight: 3
     - identifier: module
       name: Modules
@@ -87,10 +87,10 @@ menu:
       name: Demo
       weight: 20
       url: demo
-    - identifier: download 
+    - identifier: download
       name: Download
       weight: 30
-      url: https://open-emr.org/wiki/index.php/OpenEMR_Downloads
+      url: downloads
     - identifier: modules
       name: Modules
       weight: 40
@@ -192,7 +192,7 @@ params:
     name: OpenEMR
     twitter: openemr
   demoUrl: demo
-  downloadUrl: https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads
+  downloadUrl: /downloads
   footer_one_title: Main Project Links
   footer_two_title: Help & Support Links
   footer_three_title: Developer Links

--- a/content/_index.md
+++ b/content/_index.md
@@ -17,7 +17,7 @@ billboard:
       title: Find Support
       content: Find community-based or professional help.
       image: img/info.png
-    - url: https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads
+    - url: /downloads
       title: Download for Free
       content: Get the latest version for Windows, macOS, or Linux.
       image: img/download-arrow.png

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -7,4 +7,4 @@ url: downloads
 # Download OpenEMR
 
 OpenEMR is free and open source. The current stable release is below;
-older versions are listed on the [Releases]({{< relref "/releases/_index.md" >}}) page.
+older versions are listed on the [Releases]({{< ref "/releases/_index.md" >}}) page.

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -7,4 +7,4 @@ url: downloads
 # Download OpenEMR
 
 OpenEMR is free and open source. The current stable release is below;
-older versions are listed on the [Releases](/releases/) page.
+older versions are listed on the [Releases]({{< relref "/releases/_index.md" >}}) page.

--- a/content/releases/_index.md
+++ b/content/releases/_index.md
@@ -8,4 +8,4 @@ url: releases
 
 Every tagged OpenEMR release, grouped by major version.
 Release notes live on GitHub for 8.x and on the wiki for older versions.
-For the current stable download, see the [Downloads]({{< relref "/downloads/_index.md" >}}) page.
+For the current stable download, see the [Downloads]({{< ref "/downloads/_index.md" >}}) page.

--- a/content/releases/_index.md
+++ b/content/releases/_index.md
@@ -8,4 +8,4 @@ url: releases
 
 Every tagged OpenEMR release, grouped by major version.
 Release notes live on GitHub for 8.x and on the wiki for older versions.
-For the current stable download, see the [Downloads](/downloads/) page.
+For the current stable download, see the [Downloads]({{< relref "/downloads/_index.md" >}}) page.

--- a/data/releases.json
+++ b/data/releases.json
@@ -143,15 +143,17 @@
                 "install_url": "https://community.open-emr.org/t/openemr-official-docker-has-been-released/9084"
             },
             "linux": {
-                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
-                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "https://eight.openemr.io/files/openemr-linux-md5.txt"
+                "install_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
+                "upgrade_url": "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0"
             },
             "windows": {
-                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
-                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "https://eight.openemr.io/files/openemr-windows-md5.txt"
+                "install_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
+                "upgrade_url": "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0"
             }
+        },
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.0.0/openemr-8.0.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.0.0/openemr-8.0.0.zip/download"
         }
     }
 }

--- a/data/releases.json
+++ b/data/releases.json
@@ -143,12 +143,14 @@
                 "install_url": "https://community.open-emr.org/t/openemr-official-docker-has-been-released/9084"
             },
             "linux": {
-                "install_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
-                "upgrade_url": "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0"
+                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
+                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0",
+                "checksums_url": "https://www.open-emr.org/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1"
             },
             "windows": {
-                "install_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
-                "upgrade_url": "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0"
+                "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
+                "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0",
+                "checksums_url": "https://www.open-emr.org/checksums/8.0.0/openemr-8.0.0.zip.sha1"
             }
         },
         "archive_urls": {

--- a/data/releases.json
+++ b/data/releases.json
@@ -145,12 +145,12 @@
             "linux": {
                 "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
                 "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1"
+                "checksums_url": "checksums/8.0.0/openemr-8.0.0.tar.gz.sha1"
             },
             "windows": {
                 "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
                 "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "/checksums/8.0.0/openemr-8.0.0.zip.sha1"
+                "checksums_url": "checksums/8.0.0/openemr-8.0.0.zip.sha1"
             }
         },
         "archive_urls": {

--- a/data/releases.json
+++ b/data/releases.json
@@ -145,17 +145,18 @@
             "linux": {
                 "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Linux_Installation",
                 "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Linux_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "https://www.open-emr.org/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1"
+                "checksums_url": "/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1"
             },
             "windows": {
                 "install_url":   "https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_Windows_Installation",
                 "upgrade_url":   "https://www.open-emr.org/wiki/index.php/Windows_Upgrade_7.0.4_to_8.0.0",
-                "checksums_url": "https://www.open-emr.org/checksums/8.0.0/openemr-8.0.0.zip.sha1"
+                "checksums_url": "/checksums/8.0.0/openemr-8.0.0.zip.sha1"
             }
         },
         "archive_urls": {
             "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.0.0/openemr-8.0.0.tar.gz/download",
             "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.0.0/openemr-8.0.0.zip/download"
-        }
+        },
+        "patches_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_Patches"
     }
 }

--- a/data/releases.schema.json
+++ b/data/releases.schema.json
@@ -81,7 +81,7 @@
                             "properties": {
                                 "install_url":   { "type": "string", "format": "uri" },
                                 "upgrade_url":   { "type": "string", "format": "uri" },
-                                "checksums_url": { "type": "string", "format": "uri" }
+                                "checksums_url": { "type": "string", "format": "uri-reference" }
                             }
                         },
                         "windows": {
@@ -90,10 +90,15 @@
                             "properties": {
                                 "install_url":   { "type": "string", "format": "uri" },
                                 "upgrade_url":   { "type": "string", "format": "uri" },
-                                "checksums_url": { "type": "string", "format": "uri" }
+                                "checksums_url": { "type": "string", "format": "uri-reference" }
                             }
                         }
                     }
+                },
+                "patches_url": {
+                    "description": "Optional link to a wiki page listing post-release patches for this version. Rendered on the /downloads/ page as a Patches section. Present on releases (8.0.0 and earlier) that use the manual apply-patch-zip flow; omitted on 8.2.0+ where in-place upgrade automation supersedes the patch page.",
+                    "type": "string",
+                    "format": "uri"
                 }
             },
             "oneOf": [

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -110,7 +110,7 @@
                 </ul>
 
                 <h2>Older versions</h2>
-                <p>Every previous release is listed on the <a href="/releases/">Releases</a> page.</p>
+                <p>Every previous release is listed on the <a href="{{ "/releases/" | absURL }}">Releases</a> page.</p>
             </div>
         </div>
     </div>

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -59,7 +59,7 @@
                             <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.tar.gz">openemr-{{ .version }}.tar.gz</a></li>
                         {{ end }}
                         {{ with $dl.linux }}
-                            {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
+                            {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
                         {{ with (or $dl.linux.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
@@ -73,11 +73,19 @@
                             <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.zip">openemr-{{ .version }}.zip</a></li>
                         {{ end }}
                         {{ with $dl.windows }}
-                            {{ with .checksums_url }}<li><a href="{{ . }}">Checksums</a></li>{{ end }}
+                            {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
                         {{ with (or $dl.windows.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
                     </ul>
+
+                    {{ with .entry.patches_url }}
+                        <h3>Patches</h3>
+                        <p>Post-release patches are applied on top of the base install. The wiki page below lists the most recent patch and installation instructions.</p>
+                        <ul>
+                            <li><a href="{{ . }}">Latest patch and installation instructions</a></li>
+                        </ul>
+                    {{ end }}
 
                     <h3>What's in this release</h3>
                     <ul>

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -94,7 +94,7 @@
                         {{ else }}
                             <li><a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">Release notes (GitHub)</a></li>
                         {{ end }}
-                        <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_{{ .version }}_ONC_Ambulatory_EHR_Certification_Requirements">ONC Ambulatory EHR certification resources</a></li>
+                        <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_ONC_Ambulatory_EHR_Certification_Requirements">ONC Ambulatory EHR certification resources</a></li>
                     </ul>
                 {{ end }}
 

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -94,7 +94,7 @@
                         {{ else }}
                             <li><a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">Release notes (GitHub)</a></li>
                         {{ end }}
-                        <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_8.0.0_ONC_Certification">ONC Ambulatory EHR certification resources</a></li>
+                        <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_{{ .version }}_ONC_Ambulatory_EHR_Certification_Requirements">ONC Ambulatory EHR certification resources</a></li>
                     </ul>
                 {{ end }}
 

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -110,7 +110,7 @@
                 </ul>
 
                 <h2>Older versions</h2>
-                <p>Every previous release is listed on the <a href="{{ "/releases/" | absURL }}">Releases</a> page.</p>
+                <p>Every previous release is listed on the <a href="{{ "/releases/" | relURL }}">Releases</a> page.</p>
             </div>
         </div>
     </div>

--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -110,7 +110,7 @@
                 </ul>
 
                 <h2>Older versions</h2>
-                <p>Every previous release is listed on the <a href="{{ "/releases/" | relURL }}">Releases</a> page.</p>
+                <p>Every previous release is listed on the <a href="{{ (site.GetPage "/releases").Permalink }}">Releases</a> page.</p>
             </div>
         </div>
     </div>

--- a/static/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1
+++ b/static/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1
@@ -1,0 +1,1 @@
+2c8697f3c272727d1bb21678431f9c03de40aec1  openemr-8.0.0.tar.gz

--- a/static/checksums/8.0.0/openemr-8.0.0.zip.sha1
+++ b/static/checksums/8.0.0/openemr-8.0.0.zip.sha1
@@ -1,0 +1,1 @@
+08797613959a4f10ad65ac0b9e5170bd575b03a5  openemr-8.0.0.zip


### PR DESCRIPTION
## Summary

Cleans up several bugs surfaced by re-examining the current `/downloads/` page for 8.0.0. Groups related fixes so the whole picture — release-data JSON, template rendering, navigation wiring — moves together.

### 1. 8.0.0 tarball / zip URLs pointed at GitHub's auto-source archive, not a real package

Without an explicit `archive_urls`, `layouts/section/downloads.html` fell back to `github.com/openemr/openemr/archive/refs/tags/v8_0_0.tar.gz` — a raw repo dump (no vendored composer deps, no npm build artifacts), not the installable release. And `v8_0_0` has no GitHub Release at all, so `releases/download/...` URLs would 404 too.

Fixed by adding explicit `archive_urls` for 8.0.0 pointing at the SourceForge tarball and zip, matching the pattern every pre-8.0.0 FINAL entry already uses. This is the correct pattern for 8.0.0 specifically — the schema documents `archive_urls` as historical-only, and 8.2.0+ will derive URLs from GitHub Releases automatically once the release automation is running.

### 2. Checksums URLs were dead

`downloads.{linux,windows}.checksums_url` pointed at `eight.openemr.io/files/openemr-{linux,windows}-md5.txt` (502). SourceForge doesn't publish checksum sidecars for 8.0.0.

Fixed by self-hosting per-asset SHA1 sidecars under `static/checksums/8.0.0/`, computed once from the canonical SourceForge downloads:

```
static/checksums/8.0.0/openemr-8.0.0.tar.gz.sha1
    2c8697f3c272727d1bb21678431f9c03de40aec1  openemr-8.0.0.tar.gz
static/checksums/8.0.0/openemr-8.0.0.zip.sha1
    08797613959a4f10ad65ac0b9e5170bd575b03a5  openemr-8.0.0.zip
```

Standard `sha1sum -c` format. `downloads.{linux,windows}.checksums_url` now point at these sidecars.

To make the URL work in both preview and production without hardcoding a host:

- Value stored as `checksums/8.0.0/openemr-8.0.0.tar.gz.sha1` (path-relative, no leading slash — leading-slash values get their subpath dropped by Hugo's minifier when the host matches baseURL)
- Template renders through `{{ . | absURL }}` in `layouts/section/downloads.html`
- Schema widens `checksums_url` from `format: uri` → `format: uri-reference` so path-relative values validate

Absolute URLs pass through `absURL` unchanged, so this is safe for future entries that point at a GitHub Release sidecar (`.sha256` etc.).

### 3. New "Patches" section — 8.0.0-era only

The wiki `OpenEMR_Patches` page lists post-release patch zips (currently `8-0-0-Patch-3.zip`) that users apply on top of the base install. The `/downloads/` page had no link to it, so users had no clue this existed.

Adds an optional top-level `patches_url` field on the release entry:

- Schema: optional string, `format: uri`
- Template: renders a "Patches" `<h3>` block with an explanatory sentence and a single link, only when `patches_url` is set
- 8.0.0 entry: `patches_url = https://www.open-emr.org/wiki/index.php/OpenEMR_Patches`

8.2.0+ entries won't set this field — the in-place upgrade automation supersedes the manual patch-zip flow — so the section silently drops off for future releases without further code changes.

### 4. ONC certification wiki link — was 404, now version-agnostic

The "What's in this release" block linked to `OpenEMR_8.0.0_ONC_Certification` (404). The wiki has consolidated to a **version-agnostic** page: `OpenEMR_ONC_Ambulatory_EHR_Certification_Requirements` (200), which is where all future ONC cert content will live.

Template now points straight at the version-agnostic page. Same URL works whether the current stable is 8.0.0 today or 8.2.0 tomorrow, no per-release maintenance required.

### 5. Route the "Download" nav links at the on-site `/downloads/` page

Four touchpoints previously pointed at the wiki `OpenEMR_Downloads` page, which is now stale relative to `/downloads/`:

- `menu.main.download.url` → `/downloads`
- `menu.footer_one.download.url` → `downloads` (matching the footer's leading-slash-less convention used by `demo`/`modules`)
- Homepage "Download for Free" card in `content/_index.md` → `/downloads`
- `params.downloadUrl` config → `/downloads` (currently unreferenced by any template, but kept in sync)

Historical blog posts that reference the wiki download page are left alone — rewriting them would be revisionist.

### 6. Cross-page inter-navigation preserved across preview subpath

Preview builds serve the site under `/website-openemr-previews/pr-N/`, but three internal cross-page links used root-relative URLs (`/releases/`, `/downloads/`) that dropped the preview subpath and 404'd at `openemr.github.io/releases/`. Prod worked because prod's baseURL has no subpath; only preview was broken.

Fixed:

- `content/downloads/_index.md` intro: `[Releases](/releases/)` → `[Releases]({{< ref "/releases/_index.md" >}})`
- `content/releases/_index.md` intro: `[Downloads](/downloads/)` → `[Downloads]({{< ref "/downloads/_index.md" >}})`
- `layouts/section/downloads.html` "Older versions" link: `href="/releases/"` → `href="{{ (site.GetPage "/releases").Permalink }}"`

All three produce the fully-qualified URL including the subpath (which Hugo's minifier leaves alone — nothing to strip). Attempted `absURL` and `relURL` first — both got collapsed by the minifier. `Permalink` and `ref` won because they emit the canonical page URL that already includes the subpath.

## Impact on the 8.2.0 release-mechanism

None. The dispatch mechanism only writes `status`/`branch`/`sha`/`released_at` — `applyRelUpdate` and `applyTag` in `ReleasesManifest.php` preserve `archive_urls`, `downloads.*`, `compatibility`, `patches_url`, and every other key. Schema changes are additive (new optional field + widened format). Template changes to the "current stable" block use `.version` and `.entry.patches_url` so 8.2.0 will render cleanly the moment it flips to FINAL.

## Follow-up work (separate PR)

The `/releases/` page still doesn't display checksums for any version — its template only reads `.entry.archive_urls`, never `.entry.downloads.*.checksums_url`. A follow-up PR will add a **Checksums column** to `layouts/section/releases.html` and backfill SHA1 sidecars for **every pre-8.0.0 version** listed on the page so historical downloads are verifiable too.

## Test plan

- [x] JSON parses cleanly, satisfies `data/releases.schema.json` — 8.0.0 entry conforms to the "Dispatch-managed FINAL entry" `oneOf` variant (retains `branch` + `sha` + `released_at`); `archive_urls`, `patches_url` are allowed at top level; `checksums_url` accepts path-relative via `uri-reference`
- [x] All SourceForge asset URLs return 200
- [x] All wiki URLs return 200 (install/upgrade/patches/ONC)
- [x] SHA1 values verified by re-downloading each SourceForge asset and running `sha1sum`
- [x] Hugo build succeeds on CI
- [x] Preview PR renders `/downloads/` with: SourceForge tarball/zip, working per-platform Checksums links, wiki upgrade/install, Patches section, correct ONC link
- [x] Cross-page nav: click Releases from preview `/downloads/` → 200 preview `/releases/`; click Downloads from preview `/releases/` → 200 preview `/downloads/`
- [x] Top-menu / footer / homepage-card Download all land on preview `/downloads/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)