### PR TITLE
fix(downloads): derive package + sha256 URLs for dispatch-managed entries

### DIFF
--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -41,6 +41,41 @@
                         {{ $installUrl = printf "/installation/%s/" $latest.version }}
                     {{ end }}
 
+                    {{/* Resolve tar.gz + zip URLs. Historical entries (SourceForge-era)
+                         carry an explicit archive_urls block. Dispatch-managed entries
+                         (with a git sha) inherit derived URLs pointing at the packaged
+                         GitHub Release asset — NOT the auto-generated source archive at
+                         archive/refs/tags/... which is a raw repo dump. Mirrors the same
+                         resolution used on /releases/. */}}
+                    {{ $tarballUrl := "" }}
+                    {{ $zipUrl := "" }}
+                    {{ with .entry.archive_urls }}
+                        {{ $tarballUrl = .tarball }}
+                        {{ $zipUrl = .zip }}
+                    {{ else }}
+                        {{ if .entry.sha }}
+                            {{ $tarballUrl = printf "https://github.com/openemr/openemr/releases/download/%s/openemr-%s.tar.gz" $tag .version }}
+                            {{ $zipUrl = printf "https://github.com/openemr/openemr/releases/download/%s/openemr-%s.zip" $tag .version }}
+                        {{ end }}
+                    {{ end }}
+
+                    {{/* Resolve checksums. Historical + 8.0.0 use self-hosted .sha1
+                         sidecars from downloads.<platform>.checksums_url. Dispatch-managed
+                         entries without an explicit checksums_url derive a GitHub Release
+                         .sha256 sidecar — matches what the release automation emits
+                         (see v8_1_0 assets). Path-relative values render through absURL
+                         for preview-baseURL correctness. */}}
+                    {{ $linuxCk := "" }}
+                    {{ $winCk := "" }}
+                    {{ with $dl.linux }}{{ $linuxCk = .checksums_url }}{{ end }}
+                    {{ with $dl.windows }}{{ $winCk = .checksums_url }}{{ end }}
+                    {{ if and (not $linuxCk) .entry.sha }}
+                        {{ $linuxCk = printf "https://github.com/openemr/openemr/releases/download/%s/openemr-%s.tar.gz.sha256" $tag .version }}
+                    {{ end }}
+                    {{ if and (not $winCk) .entry.sha }}
+                        {{ $winCk = printf "https://github.com/openemr/openemr/releases/download/%s/openemr-%s.zip.sha256" $tag .version }}
+                    {{ end }}
+
                     <h3>Docker (recommended)</h3>
                     <p>The official OpenEMR Docker image is the recommended way to run OpenEMR.</p>
                     <ul>
@@ -53,13 +88,9 @@
 
                     <h3>Linux</h3>
                     <ul>
-                        {{ with .entry.archive_urls }}
-                            <li><a href="{{ .tarball }}">openemr-{{ $latest.version }}.tar.gz</a></li>
-                        {{ else }}
-                            <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.tar.gz">openemr-{{ .version }}.tar.gz</a></li>
-                        {{ end }}
+                        {{ with $tarballUrl }}<li><a href="{{ . }}">openemr-{{ $latest.version }}.tar.gz</a></li>{{ end }}
+                        {{ with $linuxCk }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                         {{ with $dl.linux }}
-                            {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
                         {{ with (or $dl.linux.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
@@ -67,13 +98,9 @@
 
                     <h3>Windows</h3>
                     <ul>
-                        {{ with .entry.archive_urls }}
-                            <li><a href="{{ .zip }}">openemr-{{ $latest.version }}.zip</a></li>
-                        {{ else }}
-                            <li><a href="https://github.com/openemr/openemr/archive/refs/tags/{{ $tag }}.zip">openemr-{{ .version }}.zip</a></li>
-                        {{ end }}
+                        {{ with $zipUrl }}<li><a href="{{ . }}">openemr-{{ $latest.version }}.zip</a></li>{{ end }}
+                        {{ with $winCk }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                         {{ with $dl.windows }}
-                            {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
                             {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
                         {{ end }}
                         {{ with (or $dl.windows.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}


### PR DESCRIPTION
Companion to #168 (`/releases/`), same conceptual fix applied to `/downloads/`. Ensures 8.2.0 and every future dispatch-managed FINAL release render correctly the moment they flip to \`\$latest\` — no per-release JSON edits, no workflow changes, no dispatch-payload schema changes.

## What was broken

`/downloads/` linked at GitHub's auto-generated source archive for any release without an explicit `archive_urls` block:

```
github.com/openemr/openemr/archive/refs/tags/v8_2_0.tar.gz  ← raw repo dump, not a package
```

That endpoint returns the source tree at the tag — no vendored composer deps, no npm build artifacts, not installable. It's the same bug #167 caught for 8.0.0. #167 patched 8.0.0's JSON entry (added SourceForge `archive_urls`) but left the fallback path itself broken.

And `Checksums` didn't render at all for dispatch-managed entries, because the template only checked `.entry.downloads.<platform>.checksums_url` — a field the dispatch mechanism doesn't populate.

## What this changes

Mirrors the hybrid resolution introduced on `/releases/` in #168, applied to the current-stable block of `/downloads/`:

### tar.gz + zip

```go-html-template
{{ with .entry.archive_urls }}
    {{ $tarballUrl = .tarball }}
    {{ $zipUrl = .zip }}
{{ else }}
    {{ if .entry.sha }}
        {{ $tarballUrl = printf "…/releases/download/%s/openemr-%s.tar.gz" $tag .version }}
        {{ $zipUrl     = printf "…/releases/download/%s/openemr-%s.zip"    $tag .version }}
    {{ end }}
{{ end }}
```

- Historic + 8.0.0: `archive_urls` still wins (SourceForge)
- 8.2.0+: derive `releases/download/<tag>/openemr-<version>.<ext>` — the packaged asset

### Checksums

```go-html-template
{{ with $dl.linux }}{{ $linuxCk = .checksums_url }}{{ end }}
{{ if and (not $linuxCk) .entry.sha }}
    {{ $linuxCk = printf "…/releases/download/%s/openemr-%s.tar.gz.sha256" $tag .version }}
{{ end }}
```

(and the analogous `$winCk`)

- Historic + 8.0.0: `checksums_url` still wins (self-hosted `.sha1` sidecars from #167/#168), rendered via `absURL`
- 8.2.0+: derive `.sha256` sidecar URL — matches the sidecar type the release automation emits (see v8_1_0 assets)

Both derivations key on `.entry.sha`, so historical entries never trip the fallback.

## After 8.2.0 flips FINAL

`/downloads/` will render:

```
Linux
- openemr-8.2.0.tar.gz     → github.com/openemr/openemr/releases/download/v8_2_0/openemr-8.2.0.tar.gz
- Checksums                → github.com/openemr/openemr/releases/download/v8_2_0/openemr-8.2.0.tar.gz.sha256
- Upgrade Instructions     → (whatever is set in JSON, or nothing)
- Installation Instructions → (JSON or /installation/8.2.0/ derived)

Windows
- openemr-8.2.0.zip        → github.com/openemr/openemr/releases/download/v8_2_0/openemr-8.2.0.zip
- Checksums                → github.com/openemr/openemr/releases/download/v8_2_0/openemr-8.2.0.zip.sha256
- …
```

No JSON changes required — everything derives from `.entry.sha` + `.version` + tag pattern. `applyRelUpdate` / `applyTag` in `ReleasesManifest.php` keep writing only status/branch/sha/released_at; the URL surface is entirely at render time.

## Small defensive change

Wrapped the tar.gz/zip `<li>` in `{{ with $tarballUrl }}` / `{{ with $zipUrl }}` so an unresolvable URL renders nothing instead of `<a href="">`. Not a realistic path (dispatch-managed → sha; historic → archive_urls), but the guard is one keyword.

## Files

- `layouts/section/downloads.html` — hybrid URL resolution for tar.gz / zip / checksums

Zero JSON / schema / sidecar / workflow changes.

## Test plan

- [x] Hugo build succeeds on CI
- [x] Preview `/downloads/` still renders 8.0.0 correctly (archive_urls → SourceForge, self-hosted `.sha1` sidecar linked)
- [ ] Once 8.2.0 flips FINAL, `/downloads/` shows GitHub Release tar.gz + zip + `.sha256` sidecars. (Cannot verify until a dispatch-managed FINAL entry becomes `\$latest`; validated logically here and via the identical resolution now live on `/releases/` #168.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)