### PR TITLE
feat(downloads): default install/upgrade to version-agnostic wiki pages

### DIFF
--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -32,14 +32,17 @@
 
                     {{ $dl := .entry.downloads | default dict }}
 
-                    {{/* Dispatch-driven releases (those with a branch) carry a
-                         generated /installation/<version>/ page. Derive the link
-                         here rather than storing a derivable path in the manifest,
-                         mirroring how archive_urls are derived at render time. */}}
-                    {{ $installUrl := "" }}
-                    {{ with .entry.branch }}
-                        {{ $installUrl = printf "/installation/%s/" $latest.version }}
-                    {{ end }}
+                    {{/* Version-agnostic install / upgrade wiki pages. These are the
+                         defaults for future OpenEMR releases; the wiki maintains a
+                         single canonical page per platform that covers all versions.
+                         A specific release may still override on a per-platform basis
+                         via `data/releases.json` downloads.<platform>.{install,upgrade}_url
+                         if it needs bespoke instructions (8.0.0 is grandfathered this
+                         way to per-version wiki pages). */}}
+                    {{ $defaultLinuxInstall   := "https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Installation" }}
+                    {{ $defaultLinuxUpgrade   := "https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Upgrade" }}
+                    {{ $defaultWindowsInstall := "https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Installation" }}
+                    {{ $defaultWindowsUpgrade := "https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Upgrade" }}
 
                     {{/* Resolve tar.gz + zip URLs. Historical entries (SourceForge-era)
                          carry an explicit archive_urls block. Dispatch-managed entries
@@ -90,20 +93,16 @@
                     <ul>
                         {{ with $tarballUrl }}<li><a href="{{ . }}">openemr-{{ $latest.version }}.tar.gz</a></li>{{ end }}
                         {{ with $linuxCk }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
-                        {{ with $dl.linux }}
-                            {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
-                        {{ end }}
-                        {{ with (or $dl.linux.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+                        <li><a href="{{ or $dl.linux.upgrade_url $defaultLinuxUpgrade }}">Upgrade Instructions</a></li>
+                        <li><a href="{{ or $dl.linux.install_url $defaultLinuxInstall }}">Installation Instructions</a></li>
                     </ul>
 
                     <h3>Windows</h3>
                     <ul>
                         {{ with $zipUrl }}<li><a href="{{ . }}">openemr-{{ $latest.version }}.zip</a></li>{{ end }}
                         {{ with $winCk }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
-                        {{ with $dl.windows }}
-                            {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
-                        {{ end }}
-                        {{ with (or $dl.windows.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+                        <li><a href="{{ or $dl.windows.upgrade_url $defaultWindowsUpgrade }}">Upgrade Instructions</a></li>
+                        <li><a href="{{ or $dl.windows.install_url $defaultWindowsInstall }}">Installation Instructions</a></li>
                     </ul>
 
                     {{ with .entry.patches_url }}


### PR DESCRIPTION
The wiki has consolidated per-platform install and upgrade docs into version-agnostic pages that cover every OpenEMR release, matching the same direction taken for ONC certification in #167. This PR wires the `/downloads/` template to use those pages as defaults for the current stable release, with per-version override still available in JSON.

## The four default URLs

All 200 (verified before this PR):

- <https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Installation>
- <https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Installation>
- <https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Upgrade>
- <https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Upgrade>

## Behavior

**8.0.0 (current stable)** — unchanged. Its per-version wiki URLs (`OpenEMR_8.0.0_Linux_Installation`, `Linux_Upgrade_7.0.4_to_8.0.0`, and the Windows equivalents) live in `data/releases.json` and continue to win over the template defaults. Grandfathered.

**8.2.0 (next release, when it flips FINAL)** — will render the four version-agnostic wiki URLs above automatically. Zero JSON edits required. The `downloads` block on future release entries can stay empty (or absent) and users still see working links.

**Future releases** — same as 8.2.0. If any release ever needs bespoke docs, override per-platform via `downloads.<platform>.<install|upgrade>_url` in that release's JSON entry; the template's `or` chain picks the explicit value first.

## Also: dropped a latent broken fallback

Removed the `$installUrl` derivation that generated `/installation/<version>/` as a secondary fallback for dispatch-managed releases (entries with `.entry.branch`). No `content/installation/` directory exists on this site — the page never resolved. No user-visible bug because 8.0.0 always carried an explicit `install_url` and it's always been `$latest`. The wiki-page default supersedes it cleanly.

## What changed

`layouts/section/downloads.html` current-stable block:

```diff
- {{ $installUrl := "" }}
- {{ with .entry.branch }}
-     {{ $installUrl = printf "/installation/%s/" $latest.version }}
- {{ end }}
+ {{ $defaultLinuxInstall   := "https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Installation" }}
+ {{ $defaultLinuxUpgrade   := "https://www.open-emr.org/wiki/index.php/OpenEMR_Linux_Upgrade" }}
+ {{ $defaultWindowsInstall := "https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Installation" }}
+ {{ $defaultWindowsUpgrade := "https://www.open-emr.org/wiki/index.php/OpenEMR_Windows_Upgrade" }}

  ...

  <h3>Linux</h3>
  <ul>
      ...
-     {{ with $dl.linux }}
-         {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
-         {{ with .upgrade_url }}<li><a href="{{ . }}">Upgrade Instructions</a></li>{{ end }}
-     {{ end }}
-     {{ with (or $dl.linux.install_url $installUrl) }}<li><a href="{{ . }}">Installation Instructions</a></li>{{ end }}
+     {{ with $dl.linux }}
+         {{ with .checksums_url }}<li><a href="{{ . | absURL }}">Checksums</a></li>{{ end }}
+     {{ end }}
+     <li><a href="{{ or $dl.linux.upgrade_url $defaultLinuxUpgrade }}">Upgrade Instructions</a></li>
+     <li><a href="{{ or $dl.linux.install_url $defaultLinuxInstall }}">Installation Instructions</a></li>
  </ul>
```

(Windows block same pattern.)

## Files

- `layouts/section/downloads.html` — 4 default URL constants + fallback chains for linux/windows install + upgrade

Zero JSON, schema, sidecar, or dispatch changes.

## Test plan

- [x] All four wiki URLs return 200
- [x] Hugo build succeeds on CI
- [ ] Preview `/downloads/` renders 8.0.0's per-version wiki URLs unchanged (`OpenEMR_8.0.0_Linux_Installation`, `Linux_Upgrade_7.0.4_to_8.0.0`, Windows equivalents) — regression check that the explicit JSON overrides still win
- [ ] Once 8.2.0 flips FINAL, `/downloads/` will render the four version-agnostic URLs above. Cannot verify until 8.2.0 becomes `$latest`; template logic reviewed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)