### PR TITLE
feat(release-docs): drop dependabot docker/CI bumps, keep composer + npm

### DIFF
--- a/tools/release-docs/src/ReleaseNotesGenerator.php
+++ b/tools/release-docs/src/ReleaseNotesGenerator.php
@@ -74,6 +74,32 @@ final class ReleaseNotesGenerator
      */
     private const MACHINERY_SCOPES = ['release', 'release-prep'];
 
+    /**
+     * Dependabot docker-compose group names from openemr/openemr
+     * `.github/dependabot.yml`. Grouped-update PR titles look like
+     * `bump the <group> group across N directories with M updates`;
+     * matching the group name identifies the bump as a docker-image
+     * update rather than a composer/npm package update. The
+     * source-of-truth file to check when this list feels stale is
+     * openemr/openemr's `.github/dependabot.yml` — look for the
+     * `package-ecosystem: docker-compose` blocks and their
+     * `groups:` maps.
+     *
+     * @var list<string>
+     */
+    private const DEPENDABOT_DOCKER_GROUPS = [
+        'couchdb',
+        'infrastructure',
+        'mailpit',
+        'mariadb',
+        'mysql',
+        'openemr-images',
+        'phpmyadmin',
+        'redis',
+        'selenium',
+        'selenium-updates',
+    ];
+
     public function __construct(
         private readonly ClientInterface $client,
     ) {
@@ -265,9 +291,14 @@ final class ReleaseNotesGenerator
 
     /**
      * Drop PRs that are release machinery or other non-user-facing noise:
-     * release-bot commits, [TEST] dry-run PRs, same-version dependabot
-     * no-op bumps, release/release-prep-scoped automation, and the
-     * duplicate half of a backport pair (the original is kept).
+     * release-bot commits, [TEST] dry-run PRs, dependabot bumps that are
+     * either no-op re-pins or docker-image/CI infrastructure updates,
+     * release/release-prep-scoped automation, `chore: release` stragglers,
+     * and the duplicate half of a backport pair (the original is kept).
+     *
+     * Real composer/npm dependency bumps from dependabot ARE kept — those
+     * are actual user-facing package changes. Only docker-tag and CI-only
+     * bumps are dropped.
      *
      * @param list<array{number: int, title: string, url: string, author: string}> $prs
      * @return list<array{number: int, title: string, url: string, author: string}>
@@ -299,7 +330,41 @@ final class ReleaseNotesGenerator
             return true;
         }
 
-        return $pr['author'] === self::DEPENDABOT && self::isNoOpVersionBump($title);
+        if ($pr['author'] === self::DEPENDABOT) {
+            if (self::isNoOpVersionBump($title)) {
+                return true;
+            }
+            if (self::isDockerBump($title)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * True for dependabot titles that describe a docker-image or CI
+     * infrastructure bump rather than a composer/npm package update.
+     * Two signals:
+     *
+     * - Path signal: dependabot embeds the ecosystem's target directory
+     *   in the title as `in /path/...`; docker-compose lives under
+     *   `/docker/...` or `/ci/...` in openemr/openemr.
+     * - Group signal: grouped bumps look like
+     *   `bump the <group> group ...`; the docker-compose groups from
+     *   openemr/openemr's dependabot.yml are enumerated in
+     *   DEPENDABOT_DOCKER_GROUPS.
+     */
+    private static function isDockerBump(string $title): bool
+    {
+        if (preg_match('#\bin /(?:docker|ci)/#', $title) === 1) {
+            return true;
+        }
+        $groups = implode('|', array_map(
+            static fn (string $g): string => preg_quote($g, '/'),
+            self::DEPENDABOT_DOCKER_GROUPS,
+        ));
+        return preg_match("/\\bbump the ($groups) group\\b/", $title) === 1;
     }
 
     /**

--- a/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
+++ b/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
@@ -117,15 +117,23 @@ final class ReleaseNotesGeneratorTest extends TestCase
     {
         $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
 
+        $bot = 'dependabot[bot]';
+        $dockerPath = 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3'
+            . ' in /docker/development-insane in the mailpit group across 1 directory';
+        $ciPath = 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3'
+            . ' in /ci/compose-shared-mailpit in the mailpit group across 1 directory';
+        $composerPath = 'chore(deps): bump guzzlehttp/psr7 from 2.11.0 to 2.12.1 in /tools/release-docs';
+        $npmPath = 'chore(deps): bump globals from 17.6.0 to 17.7.0 in /ccdaservice';
+
         // Path-embedded ecosystem — dependabot puts the target directory
         // in the title. Anything under /docker/... or /ci/... is a
         // docker-compose ecosystem bump, not a package the released
         // OpenEMR ships with.
         $kept = $generator->filterNoise([
-            self::authored(1, 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3 in /docker/development-insane in the mailpit group across 1 directory', 'dependabot[bot]'),
-            self::authored(2, 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3 in /ci/compose-shared-mailpit in the mailpit group across 1 directory', 'dependabot[bot]'),
-            self::authored(3, 'chore(deps): bump guzzlehttp/psr7 from 2.11.0 to 2.12.1 in /tools/release-docs', 'dependabot[bot]'),
-            self::authored(4, 'chore(deps): bump globals from 17.6.0 to 17.7.0 in /ccdaservice', 'dependabot[bot]'),
+            self::authored(1, $dockerPath, $bot),
+            self::authored(2, $ciPath, $bot),
+            self::authored(3, $composerPath, $bot),
+            self::authored(4, $npmPath, $bot),
         ]);
 
         // Kept: composer bump in /tools/release-docs, npm bump in /ccdaservice.
@@ -137,16 +145,18 @@ final class ReleaseNotesGeneratorTest extends TestCase
     {
         $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
 
+        $bot = 'dependabot[bot]';
+
         // Grouped bumps have no path in the title but name the group.
         // Docker-compose groups (per openemr/openemr's dependabot.yml)
         // are the DEPENDABOT_DOCKER_GROUPS list.
         $kept = $generator->filterNoise([
-            self::authored(1, 'chore(deps): bump the openemr-images group across 19 directories with 1 update', 'dependabot[bot]'),
-            self::authored(2, 'chore(deps): bump the mariadb group across 4 directories with 1 update', 'dependabot[bot]'),
-            self::authored(3, 'chore(deps): bump the phpmyadmin group across 3 directories with 1 update', 'dependabot[bot]'),
-            self::authored(4, 'chore(deps): bump the mailpit group across 2 directories with 1 update', 'dependabot[bot]'),
-            self::authored(5, 'chore(deps): bump the symfony group with 11 updates', 'dependabot[bot]'),
-            self::authored(6, 'chore(deps-dev): bump webpack from 5.107.2 to 5.108.1 in the build-tools group', 'dependabot[bot]'),
+            self::authored(1, 'chore(deps): bump the openemr-images group across 19 directories with 1 update', $bot),
+            self::authored(2, 'chore(deps): bump the mariadb group across 4 directories with 1 update', $bot),
+            self::authored(3, 'chore(deps): bump the phpmyadmin group across 3 directories with 1 update', $bot),
+            self::authored(4, 'chore(deps): bump the mailpit group across 2 directories with 1 update', $bot),
+            self::authored(5, 'chore(deps): bump the symfony group with 11 updates', $bot),
+            self::authored(6, 'chore(deps-dev): bump webpack from 5.107.2 to 5.108.1 in the build-tools group', $bot),
         ]);
 
         // Kept: symfony (composer group), build-tools (npm group).

--- a/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
+++ b/tools/release-docs/tests/ReleaseNotesGeneratorTest.php
@@ -113,6 +113,66 @@ final class ReleaseNotesGeneratorTest extends TestCase
         self::assertSame([1, 5, 10], array_column($kept, 'number'));
     }
 
+    public function testFilterNoiseDropsDependabotDockerBumpsByPath(): void
+    {
+        $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
+
+        // Path-embedded ecosystem — dependabot puts the target directory
+        // in the title. Anything under /docker/... or /ci/... is a
+        // docker-compose ecosystem bump, not a package the released
+        // OpenEMR ships with.
+        $kept = $generator->filterNoise([
+            self::authored(1, 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3 in /docker/development-insane in the mailpit group across 1 directory', 'dependabot[bot]'),
+            self::authored(2, 'chore(deps): bump axllent/mailpit from v1.30.2 to v1.30.3 in /ci/compose-shared-mailpit in the mailpit group across 1 directory', 'dependabot[bot]'),
+            self::authored(3, 'chore(deps): bump guzzlehttp/psr7 from 2.11.0 to 2.12.1 in /tools/release-docs', 'dependabot[bot]'),
+            self::authored(4, 'chore(deps): bump globals from 17.6.0 to 17.7.0 in /ccdaservice', 'dependabot[bot]'),
+        ]);
+
+        // Kept: composer bump in /tools/release-docs, npm bump in /ccdaservice.
+        // Dropped: docker bumps in /docker/... and /ci/...
+        self::assertSame([3, 4], array_column($kept, 'number'));
+    }
+
+    public function testFilterNoiseDropsDependabotDockerBumpsByGroupName(): void
+    {
+        $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
+
+        // Grouped bumps have no path in the title but name the group.
+        // Docker-compose groups (per openemr/openemr's dependabot.yml)
+        // are the DEPENDABOT_DOCKER_GROUPS list.
+        $kept = $generator->filterNoise([
+            self::authored(1, 'chore(deps): bump the openemr-images group across 19 directories with 1 update', 'dependabot[bot]'),
+            self::authored(2, 'chore(deps): bump the mariadb group across 4 directories with 1 update', 'dependabot[bot]'),
+            self::authored(3, 'chore(deps): bump the phpmyadmin group across 3 directories with 1 update', 'dependabot[bot]'),
+            self::authored(4, 'chore(deps): bump the mailpit group across 2 directories with 1 update', 'dependabot[bot]'),
+            self::authored(5, 'chore(deps): bump the symfony group with 11 updates', 'dependabot[bot]'),
+            self::authored(6, 'chore(deps-dev): bump webpack from 5.107.2 to 5.108.1 in the build-tools group', 'dependabot[bot]'),
+        ]);
+
+        // Kept: symfony (composer group), build-tools (npm group).
+        // Dropped: docker-compose groups.
+        self::assertSame([5, 6], array_column($kept, 'number'));
+    }
+
+    public function testFilterNoiseDropsReservedWordBotButOnlyByStandardRules(): void
+    {
+        $generator = new ReleaseNotesGenerator(self::clientReturning('{}'));
+
+        // openemr-reserved-word-bot[bot] is uncommon and its output is a
+        // legitimate chore that belongs in release notes — it isn't
+        // subject to a bot-specific always-drop rule the way the release
+        // bot is. It goes through the standard title-based filters like
+        // any other author.
+        $kept = $generator->filterNoise([
+            self::authored(1, 'chore(deps): refresh reserved-words list', 'openemr-reserved-word-bot[bot]'),
+            self::authored(2, 'chore: release 8.1.0 misc', 'openemr-reserved-word-bot[bot]'),
+        ]);
+
+        // Kept: legitimate chore.
+        // Dropped: matches the "chore: release" straggler pattern.
+        self::assertSame([1], array_column($kept, 'number'));
+    }
+
     public function testFullPipelineMatchesFixtureSnapshot(): void
     {
         $body = self::loadFixture('api-page1.json');


### PR DESCRIPTION
Preserves the original filter design from #136 (Michael A. Smith): dependabot's real dependency bumps ARE user-facing package changes and belong in release notes. Widens the existing dependabot noise filter to also drop docker-image / CI-only infrastructure bumps, which don't ship with the released OpenEMR and only clutter the release notes.

## Signal

`openemr/openemr .github/dependabot.yml` maps three package ecosystems to distinct targets:

- **`composer`** — `/` and per-module composer.json files
- **`npm`** — `/`, `/themes/openemr`, `/ccdaservice`, etc.
- **`docker-compose`** — `/docker/*` and `/ci/*`, grouped by `openemr-images`, `mariadb`, `mysql`, `phpmyadmin`, `mailpit`, `redis`, `selenium`, `selenium-updates`, `couchdb`, `infrastructure`

Dependabot embeds two of those signals in the PR title:

1. **Path signal**: `bump <pkg> from vX to vY in /docker/development-insane` — the `/docker/...` or `/ci/...` prefix identifies the docker-compose ecosystem
2. **Group signal**: `bump the openemr-images group across 19 directories with 1 update` — the group name identifies the ecosystem when no path is embedded (dependabot's grouped-update format)

New helper `isDockerBump()` matches both signals. The group list lives in `DEPENDABOT_DOCKER_GROUPS` with a docblock pointing back at openemr/openemr's dependabot.yml as source of truth for future updates.

## What changes

`isNoise()` for `dependabot[bot]` now drops if EITHER:
- `isNoOpVersionBump($title)` — same-version re-pin (existing)
- `isDockerBump($title)` — docker/CI infrastructure bump (new)

Otherwise the PR is kept — real composer/npm package updates land under `## Chores` as they always have.

## What doesn't change

- **`RELEASE_BOT`** (`openemr-release-bot[bot]`) — still always dropped
- **All non-bot title filters** — `[TEST]`, backport, release/release-prep scopes, `chore: release` — unchanged
- **`openemr-reserved-word-bot[bot]`** — subject only to standard title filters (Brady's call: uncommon enough that its output is legitimate chore content, not a noise category)
- **Any other bot** — subject only to standard title filters (behavior unchanged from #136)

## Impact on the 8.2.0 draft (PR #164)

Of the 138 dependabot rows currently on the draft:
- **81 drop** as docker/CI infrastructure (openemr-images groups, mariadb groups, `/docker/...` paths, `/ci/...` paths)
- **57 remain** as real composer/npm package updates (symfony group, guzzlehttp, league/flysystem, postcss, webpack, giggsey/libphonenumber, claimrevolution/oe-module-claimrev-connect, etc.)

The 2 `openemr-reserved-word-bot[bot]` rows continue to land under `## Chores`. `openemr-release-bot[bot]` rows continue to drop (0 in the current window).

## Tests

- `testFilterNoiseDropsMachineryAndKeepsRealChanges` — **unchanged**; Michael's original test still expresses the intent (real dep bumps kept, `[1, 5, 10]`)
- New `testFilterNoiseDropsDependabotDockerBumpsByPath` — path-signal coverage: `/docker/...` and `/ci/...` bumps dropped; `/tools/release-docs` (composer) and `/ccdaservice` (npm) kept
- New `testFilterNoiseDropsDependabotDockerBumpsByGroupName` — group coverage: `openemr-images`/`mariadb`/`phpmyadmin`/`mailpit` dropped; `symfony` (composer group) and `build-tools` (npm group) kept
- New `testFilterNoiseDropsReservedWordBotButOnlyByStandardRules` — pins the "reserved-word-bot output is legitimate chore content" directive; subject only to standard title-based filters
- Fixture snapshot unchanged — `api-page1.json` has no dependabot docker bumps to reclassify

## Trade-off: DEPENDABOT_DOCKER_GROUPS is a snapshot

The group list is a snapshot of openemr/openemr's dependabot.yml at the time of this PR. If the docker-compose groups get renamed there, this filter would silently miss them until someone updates the constant. The docblock on `DEPENDABOT_DOCKER_GROUPS` points at the source-of-truth file to keep the drift discoverable.

Path-based matching (`/docker/...`, `/ci/...`) is stable and doesn't need per-release maintenance — that's the primary signal. Group-name matching is a secondary catch for grouped bumps that don't embed the path.

## Test plan

- [x] `str_ends_with`, no lingering references to `RELEASE_BOT` / `DEPENDABOT` / `isNoOpVersionBump` (all preserved from #136 for intended reuse)
- [ ] CI: phpunit passes with the three new tests + Michael's original tests intact
- [ ] After merge, next 8.2.0 dispatch produces release-notes with docker-infra rows dropped, composer/npm rows kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)