### PR TITLE
fix(release-docs): reset data/releases.json from master in prepare-publish

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -202,6 +202,23 @@ tasks:
           # Local branch will spring into existence on first push.
           git -C "$PUBLISH" checkout -B "$BRANCH"
         fi
+        # Reset data/releases.json from master before update-manifest.php
+        # mutates it. The docs branch is a long-lived per-version branch;
+        # without this reset, each dispatch keeps mutating a stale
+        # snapshot of the manifest taken when the branch was first cut,
+        # so subsequent master updates to other entries (e.g. 8.0.0's
+        # checksums URLs or archive_urls after a hotfix PR) never
+        # propagate onto the docs branch, and the PR eventually blocks on
+        # content + formatting merge conflicts. update-manifest.php only
+        # ever adds/updates the dispatched version's entry — every other
+        # entry belongs to master alone, so starting from master's copy
+        # is always correct.
+        #
+        # The initial `git clone --depth 1` above already fetched master's
+        # HEAD as the default branch, so `origin/HEAD` is available with
+        # no extra fetch. Redundant no-op when the docs branch is fresh
+        # (first dispatch case), because it was already based on master.
+        git -C "$PUBLISH" checkout origin/HEAD -- data/releases.json
 
   workflow:commit-push:
     desc: |


### PR DESCRIPTION
Structural fix for the drift that has PR #164 currently blocked with a merge conflict.

## Root cause

The `release-docs/<version>` branches are long-lived per-version branches that get force-pushed each dispatch. `update-manifest.php` reads the branch's `data/releases.json`, mutates only the dispatched version's entry, and writes back — so once the branch was cut, every subsequent dispatch operated on a frozen snapshot of the manifest.

Consequence for PR #164 (`release-docs/8.2.0`):

- Branch was originally cut against master at `197ad76` (pre-#167)
- Between then and now, master's `data/releases.json` has moved substantially:
  - #167 fixed 8.0.0's `checksums_url` (dead `eight.openemr.io` URL → self-hosted `.sha1` sidecar)
  - #167 added `archive_urls` for 8.0.0 (SourceForge)
  - #167 added `patches_url` for 8.0.0 (wiki OpenEMR_Patches)
  - #168 normalized the whole file's formatting
- Each dispatch re-serializes the branch's frozen 8.0.0 snapshot, so the drift compounds instead of self-healing
- Current state: PR #164 shows both content drift AND formatting drift against master, and is `mergeStateStatus: DIRTY / mergeable: CONFLICTING`

## Fix

Reset `$PUBLISH/data/releases.json` from `origin/HEAD` (master) after the branch checkout in `workflow:prepare-publish`, before `update-manifest.php` runs.

```yaml
git -C "$PUBLISH" checkout origin/HEAD -- data/releases.json
```

The manifest belongs to master; the docs branch only needs to track the per-version generated content (release-notes, acknowledgements, EHI docs). Adding the reset step means every dispatch starts from master's canonical manifest and produces PR diffs limited strictly to the dispatched version's entry.

The initial `git clone --depth 1` already fetched master's HEAD as the default branch, so `origin/HEAD` resolves without an extra fetch. Verified in a fresh clone locally — `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/master`, checkout works.

## Behavior on each dispatch path

| Path | Effect |
|---|---|
| First dispatch (no existing branch — created from master) | Redundant no-op. `data/releases.json` was already at master's version. |
| Subsequent dispatch (existing branch — potentially stale snapshot) | Reset overwrites stale copy with master's current canonical copy. |

## Effect on the current 8.2.0 draft (PR #164)

Once this merges and the next rel-820 dispatch fires (which will happen automatically when #12771/#12772 land and push rel-820):

- `data/releases.json` diff in PR #164 collapses to a clean single-hunk add — the `8.2.0` DRAFT entry
- 8.0.0 content drift gone (checksums URL, archive_urls, patches_url all inherited from master)
- Formatting drift gone (post-#168 normalization inherited from master)
- Merge conflict clears

No manual overwrite of the branch needed — the pipeline self-heals on next natural dispatch.

## Test plan

- [x] `git symbolic-ref refs/remotes/origin/HEAD` resolves in a fresh `git clone --depth 1` (verified locally)
- [x] `git checkout origin/HEAD -- data/releases.json` restores the file to master's version (verified locally by manually corrupting a fresh clone's copy)
- [ ] CI: existing PHPStan/phpcs/phpunit/gen-ehi-smoke/validate-dispatch-fixtures all continue to pass (no PHP changes)
- [ ] Post-merge: next rel-820 dispatch produces a PR #164 with a clean single-entry diff for `data/releases.json`

Assisted-by: Claude Code