### PR TITLE
fix(release-docs): rebase docs branch on master each dispatch

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -194,31 +194,27 @@ tasks:
         # Enable LFS clean filters locally so committing the b10 docs tree
         # captures it as LFS objects (per the repo-root .gitattributes rule).
         git -C "$PUBLISH" lfs install --local
-        if git -C "$PUBLISH" fetch --quiet --depth 1 origin \
-            "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
-          git -C "$PUBLISH" checkout -B "$BRANCH" "origin/${BRANCH}"
-        else
-          # First dispatch for this version — branch doesn't exist yet.
-          # Local branch will spring into existence on first push.
-          git -C "$PUBLISH" checkout -B "$BRANCH"
-        fi
-        # Reset data/releases.json from master before update-manifest.php
-        # mutates it. The docs branch is a long-lived per-version branch;
-        # without this reset, each dispatch keeps mutating a stale
-        # snapshot of the manifest taken when the branch was first cut,
-        # so subsequent master updates to other entries (e.g. 8.0.0's
-        # checksums URLs or archive_urls after a hotfix PR) never
-        # propagate onto the docs branch, and the PR eventually blocks on
-        # content + formatting merge conflicts. update-manifest.php only
-        # ever adds/updates the dispatched version's entry — every other
-        # entry belongs to master alone, so starting from master's copy
-        # is always correct.
+        # Every dispatch rebases the branch on master's current HEAD.
+        # The docs branch is a working PR whose only real content is
+        # what update-manifest.php and the generators add on top of
+        # master — the per-version data/releases.json entry, and the
+        # per-version content/ files. Committing on top of the previous
+        # branch state (the pre-fix pattern) let the branch's history
+        # diverge from master indefinitely. Even after #174 fixed the
+        # file-content drift by resetting data/releases.json from
+        # master, git's 3-way merge with master still saw two divergent
+        # histories both editing the same lines with the same intent
+        # and flagged spurious conflicts.
         #
-        # The initial `git clone --depth 1` above already fetched master's
-        # HEAD as the default branch, so `origin/HEAD` is available with
-        # no extra fetch. Redundant no-op when the docs branch is fresh
-        # (first dispatch case), because it was already based on master.
-        git -C "$PUBLISH" checkout origin/HEAD -- data/releases.json
+        # Fix: always create $BRANCH fresh on master's HEAD, replacing
+        # its pre-existing state (if any) via force-push in
+        # workflow:commit-push. Each dispatch produces a single-commit
+        # branch whose merge base with master is master's current tip;
+        # the PR always merges cleanly with just the version entry +
+        # generated content as the diff. The `--depth 1` clone above
+        # already fetched master, so `origin/HEAD` resolves without an
+        # extra fetch.
+        git -C "$PUBLISH" checkout -B "$BRANCH" origin/HEAD
 
   workflow:commit-push:
     desc: |


### PR DESCRIPTION
Follow-up to #174. Fixes the "content-agrees-but-history-diverges" merge conflict on the release-docs/<version> branches.

## The problem #174 didn't catch

#174 fixed **file content** drift by resetting `data/releases.json` from master before `update-manifest.php` mutates. But the docs branches still accumulate their own per-dispatch commits ON TOP of the previous branch state. So the **git history** kept diverging from master.

Observed live on PR #164 (release-docs/8.2.0) after #174 landed and the post-merge dispatch fired:

- Direct file diff: master vs branch → clean, just the 8.2.0 DRAFT entry added
- `gh api compare/master...release-docs/8.2.0` → `ahead: 7, behind: 9`
- Actually attempting `git merge master` locally → **CONFLICT (content)** in `data/releases.json`

Root cause: master has 9 commits touching `data/releases.json` since the branch was cut. The branch has 7 commits since then (one per dispatch), each a full rewrite. Both sides edited overlapping lines with the same intent, but git's 3-way merge sees them as divergent and flags the file as CONFLICTING.

## Fix

`checkout -B $BRANCH origin/HEAD` unconditionally in `workflow:prepare-publish`. Every dispatch produces a **single-commit branch** rooted at master's current HEAD.

```diff
-        if git -C "$PUBLISH" fetch --quiet --depth 1 origin \
-            "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
-          git -C "$PUBLISH" checkout -B "$BRANCH" "origin/${BRANCH}"
-        else
-          git -C "$PUBLISH" checkout -B "$BRANCH"
-        fi
-        git -C "$PUBLISH" checkout origin/HEAD -- data/releases.json
+        git -C "$PUBLISH" checkout -B "$BRANCH" origin/HEAD
```

Since the branch is always freshly created on master's HEAD, `data/releases.json` starts as master's canonical version — the explicit reset step from #174 is subsumed and can be dropped.

`commit-push` already does the force-with-lease dance, so overwriting the remote branch is expected.

## Effect on PR #164

Once this lands and the next dispatch fires (natural rel-820 push or a manual `workflow_dispatch`), `release-docs/8.2.0` gets rewritten to a single-commit branch rooted at current master. Merge base = master's tip → 3-way merge is trivial → conflict clears → PR body diff is just the 8.2.0 DRAFT entry + regenerated `content/release-notes/8.2.0.md` + `content/acknowledgements/8.2.0.md`.

## Trade-off

Loses per-dispatch commit history on the docs branches. Nothing consumes it — each commit was a full-file rewrite anyway, and PR body/comments are where meaningful signal lives. The `EVENT` / `VERSION` / `SHA` context that used to live in commit messages continues to appear in each new dispatch's single commit message (unchanged `commit-push` code).

## Test plan

- [x] `git symbolic-ref refs/remotes/origin/HEAD` resolves in a `--depth 1` clone (verified earlier for #174)
- [ ] CI: existing PHPStan/phpcs/phpunit/gen-ehi-smoke/validate-dispatch-fixtures pass (no PHP changes)
- [ ] Post-merge: next rel-820 dispatch produces a fresh single-commit `release-docs/8.2.0` branch; `git merge master` on the branch is a clean fast-forward or no-op
- [ ] PR #164 shows `mergeable: MERGEABLE / mergeStateStatus: CLEAN` after the dispatch

Assisted-by: Claude Code