### PR TITLE
fix(release-docs): re-fetch remote branch ref so force-with-lease has a baseline

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -221,10 +221,23 @@ tasks:
         # falls to a plain `git push` which the server rejects because
         # HEAD isn't a fast-forward of the remote branch's current tip
         # (the whole point is that we're rewriting, not extending).
-        # A `|| true` swallows the exit code of an intentional miss —
-        # first dispatch on a version with no existing docs branch.
-        git -C "$PUBLISH" fetch --quiet --depth 1 origin \
-          "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
+        #
+        # Only the "remote ref doesn't exist" case is expected here
+        # (first dispatch on a new version). Every other fetch failure —
+        # network, auth, permissions — should surface in CI, not be
+        # silently swallowed: absorbing them would leave the ref
+        # unpopulated and reproduce the exact plain-push-reject bug this
+        # step is meant to prevent.
+        fetch_log=$(mktemp)
+        if ! git -C "$PUBLISH" fetch --quiet --depth 1 origin \
+            "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>"$fetch_log"; then
+          if ! grep -q "couldn't find remote ref" "$fetch_log"; then
+            cat "$fetch_log" >&2
+            rm -f "$fetch_log"
+            exit 1
+          fi
+        fi
+        rm -f "$fetch_log"
         git -C "$PUBLISH" checkout -B "$BRANCH" origin/HEAD
 
   workflow:commit-push:

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -214,6 +214,17 @@ tasks:
         # generated content as the diff. The `--depth 1` clone above
         # already fetched master, so `origin/HEAD` resolves without an
         # extra fetch.
+        #
+        # We still fetch the remote $BRANCH ref (if it exists) into
+        # refs/remotes/origin/$BRANCH so workflow:commit-push has a
+        # baseline for --force-with-lease. Without that ref, commit-push
+        # falls to a plain `git push` which the server rejects because
+        # HEAD isn't a fast-forward of the remote branch's current tip
+        # (the whole point is that we're rewriting, not extending).
+        # A `|| true` swallows the exit code of an intentional miss —
+        # first dispatch on a version with no existing docs branch.
+        git -C "$PUBLISH" fetch --quiet --depth 1 origin \
+          "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
         git -C "$PUBLISH" checkout -B "$BRANCH" origin/HEAD
 
   workflow:commit-push:


### PR DESCRIPTION
Follow-up to #175. My rebase-per-dispatch change dropped the branch-ref fetch alongside the branch-specific checkout, which broke `workflow:commit-push`'s push path on any subsequent dispatch to an existing docs branch.

## What broke

`commit-push`'s push logic branches on whether `refs/remotes/origin/\$BRANCH` exists locally:

```bash
if base=\$(git rev-parse --verify --quiet "refs/remotes/origin/\$BRANCH"); then
  git push --force-with-lease="refs/heads/\$BRANCH:\$base" origin "HEAD:\$BRANCH"
else
  # first-dispatch fallback: plain push creates the new branch
  git push origin "HEAD:\$BRANCH"
fi
```

Post-#175 the ref no longer exists locally (I removed the fetch that populated it). So `commit-push` falls to the plain-push branch. But the remote `release-docs/8.2.0` already has 7 pre-existing commits from earlier dispatches — plain push is rejected with:

```
 ! [rejected]        HEAD -> release-docs/8.2.0 (fetch first)
error: failed to push some refs
```

Observed live in release-docs.yml run [28750381998](https://github.com/openemr/website-openemr/actions/runs/28750381998), the workflow_dispatch Brady manually triggered at 18:19 UTC to heal PR #164.

## Fix

Restore the fetch of the remote branch ref alongside the master-based checkout in `prepare-publish`:

```diff
+        git -C "\$PUBLISH" fetch --quiet --depth 1 origin \
+          "+refs/heads/\${BRANCH}:refs/remotes/origin/\${BRANCH}" 2>/dev/null || true
         git -C "\$PUBLISH" checkout -B "\$BRANCH" origin/HEAD
```

When the remote branch exists → `refs/remotes/origin/\$BRANCH` gets populated → `commit-push` uses `--force-with-lease` with the current tip as baseline → force-push succeeds and overwrites the divergent history with a fresh single-commit branch on master.

When the remote branch doesn't exist (first-dispatch on a new version) → the fetch silently fails → the ref stays absent → `commit-push`'s `else` branch handles the create-new-branch case as before.

The `|| true` swallows the fetch's exit code on an intentional miss (first-dispatch), which is exactly how the original pre-#175 code handled it too (via the `2>/dev/null` and the surrounding `if`).

## Effect on PR #164

Next dispatch after this merges will:
1. Fetch `release-docs/8.2.0` (populates `refs/remotes/origin/release-docs/8.2.0`)
2. Create branch fresh on master's HEAD (per #175)
3. Generate content + commit
4. `commit-push` sees the remote ref, uses `--force-with-lease`, force-pushes cleanly
5. PR #164's branch tip is rewritten to a single-commit branch on master → conflict clears

Then the natural workflow-dispatch retry (or next rel-820 push) heals PR #164.

## Test plan

- [x] Fetch-with-fallback pattern replicates the pre-#175 code (also had `2>/dev/null` and swallowed miss via surrounding `if`)
- [ ] CI: existing PHPStan/phpcs/phpunit pass (no PHP changes)
- [ ] Post-merge: manual `workflow_dispatch` to release-prep.yml on rel-820 succeeds and pushes updated `release-docs/8.2.0`
- [ ] PR #164 shows `mergeable: MERGEABLE, mergeStateStatus: CLEAN` after the push

Assisted-by: Claude Code