### PR TITLE
chore(releases): ksort data/releases.json to match pipeline output

### DIFF
--- a/data/releases.json
+++ b/data/releases.json
@@ -1,4 +1,156 @@
 {
+    "2.7.2": {
+        "status": "FINAL",
+        "released_at": "2005-06-01",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.7.2/openemr-2.7.2.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.7.2/openemr-2.7.2.tar.gz.sha1"
+            }
+        }
+    },
+    "2.8.0": {
+        "status": "FINAL",
+        "released_at": "2005-11-11",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.0/openemr-2.8.0.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.8.0/openemr-2.8.0.tar.gz.sha1"
+            }
+        }
+    },
+    "2.8.1": {
+        "status": "FINAL",
+        "released_at": "2006-01-17",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.1/openemr-2.8.1.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.8.1/openemr-2.8.1.tar.gz.sha1"
+            }
+        }
+    },
+    "2.8.2": {
+        "status": "FINAL",
+        "released_at": "2007-01-14",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.2/openemr-2.8.2.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.8.2/openemr-2.8.2.tar.gz.sha1"
+            }
+        }
+    },
+    "2.8.3": {
+        "status": "FINAL",
+        "released_at": "2007-08-22",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.3/openemr-2.8.3.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.3/openemr-2.8.3.zip/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.8.3/openemr-2.8.3.tar.gz.sha1"
+            },
+            "windows": {
+                "checksums_url": "checksums/2.8.3/openemr-2.8.3.zip.sha1"
+            }
+        }
+    },
+    "2.9.0": {
+        "status": "FINAL",
+        "released_at": "2008-08-06",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.9.0/openemr-2.9.0.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/2.9.0/openemr-2.9.0.tar.gz.sha1"
+            }
+        }
+    },
+    "3.0.0": {
+        "status": "FINAL",
+        "released_at": "2009-03-15",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.0/openemr-3.0.0.tar.gz/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/3.0.0/openemr-3.0.0.tar.gz.sha1"
+            }
+        }
+    },
+    "3.0.1": {
+        "status": "FINAL",
+        "released_at": "2009-03-31",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.1/openemr-3.0.1.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.1/openemr-3.0.1.zip/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/3.0.1/openemr-3.0.1.tar.gz.sha1"
+            },
+            "windows": {
+                "checksums_url": "checksums/3.0.1/openemr-3.0.1.zip.sha1"
+            }
+        }
+    },
+    "3.1.0": {
+        "status": "FINAL",
+        "released_at": "2009-08-24",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.1.0/openemr-3.1.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.1.0/openemr-3.1.0.zip/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/3.1.0/openemr-3.1.0.tar.gz.sha1"
+            },
+            "windows": {
+                "checksums_url": "checksums/3.1.0/openemr-3.1.0.zip.sha1"
+            }
+        }
+    },
+    "3.2.0": {
+        "status": "FINAL",
+        "released_at": "2010-02-15",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.2.0/openemr-3.2.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.2.0/openemr-3.2.0.zip/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/3.2.0/openemr-3.2.0.tar.gz.sha1"
+            },
+            "windows": {
+                "checksums_url": "checksums/3.2.0/openemr-3.2.0.zip.sha1"
+            }
+        }
+    },
+    "4.0.0": {
+        "status": "FINAL",
+        "released_at": "2011-03-26",
+        "archive_urls": {
+            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.0.0/openemr-4.0.0.tar.gz/download",
+            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.0.0/openemr-4.0.0.zip/download"
+        },
+        "downloads": {
+            "linux": {
+                "checksums_url": "checksums/4.0.0/openemr-4.0.0.tar.gz.sha1"
+            },
+            "windows": {
+                "checksums_url": "checksums/4.0.0/openemr-4.0.0.zip.sha1"
+            }
+        }
+    },
     "4.1.0": {
         "status": "FINAL",
         "released_at": "2011-09-21",
@@ -295,157 +447,5 @@
             "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/8.0.0/openemr-8.0.0.zip/download"
         },
         "patches_url": "https://www.open-emr.org/wiki/index.php/OpenEMR_Patches"
-    },
-    "2.7.2": {
-        "status": "FINAL",
-        "released_at": "2005-06-01",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.7.2/openemr-2.7.2.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.7.2/openemr-2.7.2.tar.gz.sha1"
-            }
-        }
-    },
-    "2.8.0": {
-        "status": "FINAL",
-        "released_at": "2005-11-11",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.0/openemr-2.8.0.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.8.0/openemr-2.8.0.tar.gz.sha1"
-            }
-        }
-    },
-    "2.8.1": {
-        "status": "FINAL",
-        "released_at": "2006-01-17",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.1/openemr-2.8.1.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.8.1/openemr-2.8.1.tar.gz.sha1"
-            }
-        }
-    },
-    "2.8.2": {
-        "status": "FINAL",
-        "released_at": "2007-01-14",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.2/openemr-2.8.2.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.8.2/openemr-2.8.2.tar.gz.sha1"
-            }
-        }
-    },
-    "2.8.3": {
-        "status": "FINAL",
-        "released_at": "2007-08-22",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.3/openemr-2.8.3.tar.gz/download",
-            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.8.3/openemr-2.8.3.zip/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.8.3/openemr-2.8.3.tar.gz.sha1"
-            },
-            "windows": {
-                "checksums_url": "checksums/2.8.3/openemr-2.8.3.zip.sha1"
-            }
-        }
-    },
-    "2.9.0": {
-        "status": "FINAL",
-        "released_at": "2008-08-06",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/2.9.0/openemr-2.9.0.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/2.9.0/openemr-2.9.0.tar.gz.sha1"
-            }
-        }
-    },
-    "3.0.0": {
-        "status": "FINAL",
-        "released_at": "2009-03-15",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.0/openemr-3.0.0.tar.gz/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/3.0.0/openemr-3.0.0.tar.gz.sha1"
-            }
-        }
-    },
-    "3.0.1": {
-        "status": "FINAL",
-        "released_at": "2009-03-31",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.1/openemr-3.0.1.tar.gz/download",
-            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.0.1/openemr-3.0.1.zip/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/3.0.1/openemr-3.0.1.tar.gz.sha1"
-            },
-            "windows": {
-                "checksums_url": "checksums/3.0.1/openemr-3.0.1.zip.sha1"
-            }
-        }
-    },
-    "3.1.0": {
-        "status": "FINAL",
-        "released_at": "2009-08-24",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.1.0/openemr-3.1.0.tar.gz/download",
-            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.1.0/openemr-3.1.0.zip/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/3.1.0/openemr-3.1.0.tar.gz.sha1"
-            },
-            "windows": {
-                "checksums_url": "checksums/3.1.0/openemr-3.1.0.zip.sha1"
-            }
-        }
-    },
-    "3.2.0": {
-        "status": "FINAL",
-        "released_at": "2010-02-15",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.2.0/openemr-3.2.0.tar.gz/download",
-            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/3.2.0/openemr-3.2.0.zip/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/3.2.0/openemr-3.2.0.tar.gz.sha1"
-            },
-            "windows": {
-                "checksums_url": "checksums/3.2.0/openemr-3.2.0.zip.sha1"
-            }
-        }
-    },
-    "4.0.0": {
-        "status": "FINAL",
-        "released_at": "2011-03-26",
-        "archive_urls": {
-            "tarball": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.0.0/openemr-4.0.0.tar.gz/download",
-            "zip": "https://sourceforge.net/projects/openemr/files/OpenEMR%20Current/4.0.0/openemr-4.0.0.zip/download"
-        },
-        "downloads": {
-            "linux": {
-                "checksums_url": "checksums/4.0.0/openemr-4.0.0.tar.gz.sha1"
-            },
-            "windows": {
-                "checksums_url": "checksums/4.0.0/openemr-4.0.0.zip.sha1"
-            }
-        }
     }
 }


### PR DESCRIPTION
Follow-up to #177. My #177 Python script appended the 11 new pre-4.1.0 entries to the end of `data/releases.json` without sorting, so master's file ended up in an odd order:

```
4.1.0, 4.1.1, ..., 8.0.0, 2.7.2, 2.8.0, ..., 4.0.0
```

Meanwhile the release-docs pipeline's `ReleasesManifest::save()` calls `ksort($manifest)` before serializing, so every dispatch produces the **canonical sorted order** on the `release-docs/<version>` branch:

```
2.7.2, 2.8.0, ..., 8.0.0, 8.2.0
```

Consequence: PR #164 (the 8.2.0 draft) showed a **304-line diff** against master (152 insertions + 152 deletions) even though the content was functionally identical — same entries, same fields, just reordered.

## Fix

Apply the pipeline's exact `ksort` + `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES` semantics to the file on-disk. This is a **pure reordering** — zero content change.

```php
ksort($data);
json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n"
```

After this lands, future dispatches produce zero-diff output for unchanged entries, and PR #164 auto-heals to a clean single-hunk diff (just the 8.2.0 DRAFT addition).

## Test plan

- [x] `data/releases.json` still parses as valid JSON (28 FINAL entries preserved)
- [x] Every entry's fields byte-identical to pre-sort (verified via decoded-content comparison)
- [x] File format matches what `ReleasesManifest::save()` produces (`JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR`)
- [ ] CI: Hugo build succeeds, existing tests pass (no PHP or schema changes)
- [ ] After merge: PR #164's next dispatch produces a clean single-hunk diff instead of the current 304-line reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)