### PR TITLE
release-docs: OpenEMR 8.2.0 (DRAFT) — acknowledgements + release-notes recovery

### DIFF
--- a/content/acknowledgements/8.2.0.md
+++ b/content/acknowledgements/8.2.0.md
@@ -1,0 +1,62 @@
+---
+title: "OpenEMR 8.2.0 Acknowledgements"
+version: "8.2.0"
+---
+
+{{< release-status version="8.2.0" >}}
+
+# OpenEMR 8.2.0 — Acknowledgements
+
+OpenEMR 8.2.0 exists thanks to the work of the following contributors.
+Counts reflect commits to 8.2.0 on the openemr/openemr repository.
+
+- Michael A. Smith (428 commits)
+- Eric Stern (216 commits)
+- Brady Miller (122 commits)
+- haoyu-haoyu (29 commits)
+- craigrallen (23 commits)
+- Stephen Nielson (19 commits)
+- Copilot (16 commits)
+- Stephen Waite (16 commits)
+- steve waite (16 commits)
+- Jerry Padgett (11 commits)
+- Milan Zivkovic (6 commits)
+- Sherwin Gaddis (6 commits)
+- Fabricio Orrala (5 commits)
+- Igor Mukhin (5 commits)
+- Josh Baiad (5 commits)
+- Chris Dickman (4 commits)
+- Andrew Alanis (2 commits)
+- Daniel Bates (2 commits)
+- Desel72 (2 commits)
+- KIRAN (2 commits)
+- Mihir Wadekar (2 commits)
+- SMART (2 commits)
+- Vitalii Boiko (2 commits)
+- ksrm (2 commits)
+- ruth (2 commits)
+- Aanand S J (1 commit)
+- Alan Bishop (1 commit)
+- Brian Banerjee (1 commit)
+- Claw Explorer (1 commit)
+- Gregory Reeves (1 commit)
+- Jack Stringer (1 commit)
+- James Robinson (1 commit)
+- Josh Aiken (1 commit)
+- Matthias Schoettle (1 commit)
+- Meghana Chowdary Ainampudi (1 commit)
+- Minh Lê (1 commit)
+- Petr Simecek (1 commit)
+- Raphael Malikian (1 commit)
+- Stephane Deuvaert (1 commit)
+- Tim Swagger (1 commit)
+- cdx@rolling.ventures (1 commit)
+- claimrevolution (1 commit)
+- corevibe555 (1 commit)
+- egearman (1 commit)
+- lilit1121 (1 commit)
+- margarethaywood (1 commit)
+- mattpolly (1 commit)
+- mdsupport (1 commit)
+- ophthal (1 commit)
+- takidisk (1 commit)

--- a/content/release-notes/8.2.0.md
+++ b/content/release-notes/8.2.0.md
@@ -1,0 +1,979 @@
+---
+title: "OpenEMR 8.2.0 Release Notes"
+version: "8.2.0"
+---
+
+{{< release-status version="8.2.0" >}}
+
+# OpenEMR 8.2.0 — Release Notes
+
+## Features
+
+- [#12822](https://github.com/openemr/openemr/pull/12822) feat(portal): Add view only mode to portal appointments — @bradymiller
+- [#12820](https://github.com/openemr/openemr/pull/12820) feat(portal): Add view only mode to portal appointments — @sjpadgett
+- [#12810](https://github.com/openemr/openemr/pull/12810) feat(database): add DBAL query-audit middleware — @Firehed
+- [#12753](https://github.com/openemr/openemr/pull/12753) feat(bc): add internal deprecation utility — @Firehed
+- [#12651](https://github.com/openemr/openemr/pull/12651) feat(docker): declare HOST_UID/HOST_GID env in insane dev compose — @bradymiller
+- [#12647](https://github.com/openemr/openemr/pull/12647) feat(docker): declare HOST_UID/HOST_GID env in dev compose files — @bradymiller
+- [#12642](https://github.com/openemr/openemr/pull/12642) feat(flex): honor HOST_UID/HOST_GID for apache uid alignment — @bradymiller
+- [#12609](https://github.com/openemr/openemr/pull/12609) feat(docker): add fsupgrade-11.sh for 8.1.1 release (master sync) — @bradymiller
+- [#12608](https://github.com/openemr/openemr/pull/12608) feat(docker): add fsupgrade-11.sh for 8.1.1 release on rel-810 — @bradymiller
+- [#12603](https://github.com/openemr/openemr/pull/12603) feat(codes): Modernized DBAL/ORM service path for code type syncing — @Firehed
+- [#12580](https://github.com/openemr/openemr/pull/12580) feat(ci): add byte-identical canary + config to FILES_ALL with context-aware diff logic — @bradymiller
+- [#12577](https://github.com/openemr/openemr/pull/12577) feat(ci): auto-sync byte-identical files from master to rel branches — @bradymiller
+- [#12539](https://github.com/openemr/openemr/pull/12539) feat(dx): Add REPL tool for dev envs — @Firehed
+- [#12534](https://github.com/openemr/openemr/pull/12534) feat(insurance): client-side phone/fax validation on insurance + pharmacy edit forms — @bradymiller
+- [#12481](https://github.com/openemr/openemr/pull/12481) feat(routing): Symfony-routing strangler seam for zend_modules — @kojiromike
+- [#12484](https://github.com/openemr/openemr/pull/12484) feat(faxsms): encrypt unassigned inbound faxes at rest — @bradymiller
+- [#11265](https://github.com/openemr/openemr/pull/11265) feat(claimrev): install ClaimRev Connect module as Composer dependency — @claimrevolution
+- [#12397](https://github.com/openemr/openemr/pull/12397) feat(ehi): extract (b)(10) EHI table set to b10-tables.yml — @kojiromike
+- [#12267](https://github.com/openemr/openemr/pull/12267) feat(cli): refuse to run OpenEMR CLI as root — @bradymiller
+- [#12335](https://github.com/openemr/openemr/pull/12335) feat(phpstan): SqlReservedWordRule + automated MySQL/MariaDB drift detection — @bradymiller
+- [#12163](https://github.com/openemr/openemr/pull/12163) feat(vitals): add input validation for numeric fields — @lilit1121
+- [#11973](https://github.com/openemr/openemr/pull/11973) feat(crypto): add database encryption opt-out setting — @Firehed
+- [#12096](https://github.com/openemr/openemr/pull/12096) feat(crypto): add encryption status check methods and conditional database encryption — @Firehed
+- [#12093](https://github.com/openemr/openemr/pull/12093) feat(encryption): Add DBAL-based key storage and extract loadWithEngines — @Firehed
+- [#11912](https://github.com/openemr/openemr/pull/11912) feat(auth): add audit logging for failed TOTP, U2F, and OAuth2 MFA attempts — @aanand-1706
+- [#12000](https://github.com/openemr/openemr/pull/12000) feat(crypto): Refactor filesystem encryption — @Firehed
+- [#12035](https://github.com/openemr/openemr/pull/12035) feat(ci): auto-merge dependabot docker-compose updates — @bradymiller
+- [#11594](https://github.com/openemr/openemr/pull/11594) feat(phpstan): add rule to forbid CoversClass/CoversFunction attributes — @kojiromike
+- [#11621](https://github.com/openemr/openemr/pull/11621) feat(phpstan): forbid unsafe catch blocks and exit/die inside them — @Firehed
+- [#11631](https://github.com/openemr/openemr/pull/11631) feat(cli): Expose installer in symfony/console command — @Firehed
+- [#11650](https://github.com/openemr/openemr/pull/11650) feat(phpstan): forbid shell execution functions and eval() — @kojiromike
+- [#11687](https://github.com/openemr/openemr/pull/11687) feat(background-services): add run-all-due REST and CLI entry points — @kojiromike
+- [#11705](https://github.com/openemr/openemr/pull/11705) feat(ci): Run API tests through Front Controller — @Firehed
+- [#11742](https://github.com/openemr/openemr/pull/11742) feat(db): Base-level ORM installation — @Firehed
+- [#11797](https://github.com/openemr/openemr/pull/11797) feat(storage): add CacheDirectory for secure cache paths — @Firehed
+- [#11830](https://github.com/openemr/openemr/pull/11830) feat(cli): add API enablement flags to install command — @Firehed
+- [#11946](https://github.com/openemr/openemr/pull/11946) feat(crypto): add encryptForDatabase and decryptFromDatabase methods — @Firehed
+- [#10904](https://github.com/openemr/openemr/pull/10904) feat(validation): add email_direct validation and native email input type (#10866) — @craigrallen
+- [#8220](https://github.com/openemr/openemr/pull/8220) feat(flow-board): show lock icon for signed/locked encounters — @juggernautsei
+- [#11559](https://github.com/openemr/openemr/pull/11559) feat: support redis session locking and fix redis encryption support over wire — @bradymiller
+- [#11519](https://github.com/openemr/openemr/pull/11519) feat(storage): Flysystem setup; first example integration — @Firehed
+- [#10943](https://github.com/openemr/openemr/pull/10943) feat(cli): Add doctrine/migrations to cli — @Firehed
+- [#11139](https://github.com/openemr/openemr/pull/11139) feat(crypto): Separate password encryption (2/2) — @Firehed
+- [#11135](https://github.com/openemr/openemr/pull/11135) feat(crypto): Separate password encryption (1/2) — @Firehed
+- [#11448](https://github.com/openemr/openemr/pull/11448) feat(encryption): Key material storage APIs — @Firehed
+- [#11475](https://github.com/openemr/openemr/pull/11475) feat(encryption): New core API - `CipherSuiteInterface` — @Firehed
+- [#11452](https://github.com/openemr/openemr/pull/11452) feat(encryption): CryptoInterface and modern Encryption compatibility bridge — @Firehed
+- [#11378](https://github.com/openemr/openemr/pull/11378) feat(email): add email send test to admin interface — @kojiromike
+- [#11337](https://github.com/openemr/openemr/pull/11337) feat(background-services): add REST API endpoints for listing and triggering services — @kojiromike
+- [#11335](https://github.com/openemr/openemr/pull/11335) feat(background-services): add CLI tooling for listing, running, and crontab generation — @kojiromike
+- [#11424](https://github.com/openemr/openemr/pull/11424) feat(ui): display software version in fixed footer — @kojiromike
+- [#11410](https://github.com/openemr/openemr/pull/11410) feat: support worktrees in the easy dev environments — @bradymiller
+- [#9943](https://github.com/openemr/openemr/pull/9943) feat(routing): Initial front-controller implementation — @Firehed
+- [#11002](https://github.com/openemr/openemr/pull/11002) feat(branding): make main menu logo link and title configurable (#10986) — @craigrallen
+- [#11294](https://github.com/openemr/openemr/pull/11294) feat(encryption): Add encrypt methods to new ciphers — @Firehed
+- [#11250](https://github.com/openemr/openemr/pull/11250) feat(phpstan): forbid direct access to request superglobals — @kojiromike
+- [#11001](https://github.com/openemr/openemr/pull/11001) feat(config): Start to set up PSR-11 DI container — @Firehed
+- [#11138](https://github.com/openemr/openemr/pull/11138) feat(database): Add ConnectionManager for named database connections — @Firehed
+- [#10795](https://github.com/openemr/openemr/pull/10795) feat(phpstan): Add rule for blocking direct instantiation of certain classes — @Firehed
+- [#10778](https://github.com/openemr/openemr/pull/10778) feat(db): Migrate ADODB setup in Gacl to new factory method — @Firehed
+- [#10776](https://github.com/openemr/openemr/pull/10776) feat(db): Prepare central ADODB setup — @Firehed
+- [#11379](https://github.com/openemr/openemr/pull/11379) feat(csrf): add CsrfUtils::checkCsrfInput() convenience method — @kojiromike
+- [#10244](https://github.com/openemr/openemr/pull/10244) feat(session): porting core and portal apps to HttpSessionFactory — @zmilan
+- [#11056](https://github.com/openemr/openemr/pull/11056) feat(users): add email field to user admin UI — @rollingventures
+- [#11075](https://github.com/openemr/openemr/pull/11075) feat: other payer claim control number for secondary claims — @stephenwaite
+- [#10837](https://github.com/openemr/openemr/pull/10837) feat(api): add prescription REST API endpoints with tests — @kojiromike
+- [#10806](https://github.com/openemr/openemr/pull/10806) feat(patients): optionally generate csv file of duplicate patients — @ruthkonyn
+- [#10777](https://github.com/openemr/openemr/pull/10777) feat(db): Migrate ADODB setup in sql.inc to new factory method — @Firehed
+- [#8932](https://github.com/openemr/openemr/pull/8932) feat(api): add missing appointment fields and auto-set pc_time/pc_informant — @tswagger
+- [#10704](https://github.com/openemr/openemr/pull/10704) feat(db): Support Doctrine migrations for new schema migrations — @Firehed
+- [#10723](https://github.com/openemr/openemr/pull/10723) feat(ci): Add workflow summaries for PHPStan failures — @kojiromike
+- [#10720](https://github.com/openemr/openemr/pull/10720) feat(phpstan): add generator for database table type aliases — @kojiromike
+- [#10719](https://github.com/openemr/openemr/pull/10719) feat(db): add structure to connection parsing, prepare reading socket option — @Firehed
+- [#10674](https://github.com/openemr/openemr/pull/10674) feat(internals): add ServiceContainer for centralized service access — @Firehed
+- [#10715](https://github.com/openemr/openemr/pull/10715) feat(phpstan): Add deprecation rules for PHPStan — @Firehed
+- [#10697](https://github.com/openemr/openemr/pull/10697) feat(phpstan): enforce literal-string for translation functions — @kojiromike
+- [#10643](https://github.com/openemr/openemr/pull/10643) feat(facility): add organization type field — @kojiromike
+- [#10679](https://github.com/openemr/openemr/pull/10679) feat(core): add typed getKernel() method to OEGlobalsBag — @kojiromike
+- [#10616](https://github.com/openemr/openemr/pull/10616) feat(phpstan): add rule to forbid empty() in favor of explicit checks — @kojiromike
+
+## Bug Fixes
+
+- [#12842](https://github.com/openemr/openemr/pull/12842) fix(translation): Ensure xl() doesn't leave hints when translation is disabled — @Firehed
+- [#12840](https://github.com/openemr/openemr/pull/12840) fix(sql-upgrade): version-check backup + smart dropdown default — @bradymiller
+- [#12826](https://github.com/openemr/openemr/pull/12826) fix(sql-upgrade): server-status polling now terminates reliably — @bradymiller
+- [#12831](https://github.com/openemr/openemr/pull/12831) fix(sql-upgrade): skip audit logging on the status poll endpoint — @bradymiller
+- [#12652](https://github.com/openemr/openemr/pull/12652) fix(edihistory): strict types string errors — @stephenwaite
+- [#12569](https://github.com/openemr/openemr/pull/12569) fix(core): prevent {headerTemplate} from rendering the page header twice — @dac-ai-worker
+- [#12821](https://github.com/openemr/openemr/pull/12821) fix(core): prevent {headerTemplate} from rendering the page header twice — @bradymiller
+- [#12765](https://github.com/openemr/openemr/pull/12765) fix(ccda): CCDA to pass ONC USCDI V3 test scenarios. — @sjpadgett
+- [#12815](https://github.com/openemr/openemr/pull/12815) fix(ccda): CCDA to pass ONC USCDI V3 test scenarios. — @bradymiller
+- [#11369](https://github.com/openemr/openemr/pull/11369) fix: resolve PHP deprecation warnings and undefined variable errors — @claw-explorer
+- [#12691](https://github.com/openemr/openemr/pull/12691) fix(modules): Move module loading after OPENEMR_GLOBALS_LOADED — @Firehed
+- [#12653](https://github.com/openemr/openemr/pull/12653) fix(gacl): Fix invalid property access in gacl — @Firehed
+- [#12648](https://github.com/openemr/openemr/pull/12648) fix(spell): exclude CHANGELOG line quoting 'Dislay' typo from codespell — @bradymiller
+- [#12632](https://github.com/openemr/openemr/pull/12632) fix(docker): irp imports 0 patients because synthea output is in root-only /root/ — @bradymiller
+- [#12547](https://github.com/openemr/openemr/pull/12547) fix(docker): checkout repo before flex build to dodge submodule recursion — @bradymiller
+- [#12604](https://github.com/openemr/openemr/pull/12604) fix(ci): Restore Inferno after docker rearranging — @Firehed
+- [#12597](https://github.com/openemr/openemr/pull/12597) fix(ci): docker-validate-release-targets reads master version.php from PR checkout — @bradymiller
+- [#12594](https://github.com/openemr/openemr/pull/12594) fix(ci): sync-byte-identical handles rename + removed-from-config — @bradymiller
+- [#12585](https://github.com/openemr/openemr/pull/12585) fix(ci): only require release-targets.yml in master context for byte-identical canary — @bradymiller
+- [#12538](https://github.com/openemr/openemr/pull/12538) fix(insurance): clear phone_numbers before re-insert in legacy persist + cleanup migration — @bradymiller
+- [#12570](https://github.com/openemr/openemr/pull/12570) fix(contrib): repair trailing comma in Pain_Initial_Assessment.json — @bradymiller
+- [#12548](https://github.com/openemr/openemr/pull/12548) fix(docker): add php-posix to the flex image apk install list — @bradymiller
+- [#12529](https://github.com/openemr/openemr/pull/12529) fix(persist): skip phones the legacy parts schema cannot represent (insurance + pharmacy) — @bradymiller
+- [#12524](https://github.com/openemr/openemr/pull/12524) fix(deps): Harden dependencies by pulling in security meta-package — @Firehed
+- [#12525](https://github.com/openemr/openemr/pull/12525) fix: prevent PHP 8 TypeError in Claim::payerCount() and procCount() — @rtmalikian
+- [#12520](https://github.com/openemr/openemr/pull/12520) fix(calendar): restore appointments hidden after 8.0→8.1 upgrade — @kojiromike
+- [#12519](https://github.com/openemr/openemr/pull/12519) fix(calendar): restore appointments hidden after 8.0→8.1 upgrade — @kojiromike
+- [#12400](https://github.com/openemr/openemr/pull/12400) fix(reminders): Numerous bug fixes — @sjpadgett
+- [#12473](https://github.com/openemr/openemr/pull/12473) fix(password): expired password warning not displaying — @stephenwaite
+- [#12472](https://github.com/openemr/openemr/pull/12472) fix(ci): don't run sql_upgrade as root in Inferno test — @Firehed
+- [#12444](https://github.com/openemr/openemr/pull/12444) fix(calendar): allow save for timed In/Out of Office events — @bradymiller
+- [#10989](https://github.com/openemr/openemr/pull/10989) fix(portal): block negative or zero patient payment amounts — @craigrallen
+- [#12399](https://github.com/openemr/openemr/pull/12399) fix(fhir): make generated Observation value[x] PHPDoc nullable — @kojiromike
+- [#12353](https://github.com/openemr/openemr/pull/12353) fix(payments): edit payment sql error — @stephenwaite
+- [#12327](https://github.com/openemr/openemr/pull/12327) fix(oauth): use spec-compliant `invalid_request` error code (remove stray space) — @DucMinhNe
+- [#12339](https://github.com/openemr/openemr/pull/12339) fix(payments): add cryptogen to front_payment.php — @stephenwaite
+- [#12340](https://github.com/openemr/openemr/pull/12340) fix(sql): backtick bare `system` in ContactTelecomService for MySQL 8+ compat — @bradymiller
+- [#12329](https://github.com/openemr/openemr/pull/12329) fix(sql): backtick `rank` column in ContactTelecomService for MySQL 8+ compat — @bradymiller
+- [#12273](https://github.com/openemr/openemr/pull/12273) fix(globals): stop forcing E_ALL error reporting and add reporting options — @sjpadgett
+- [#12007](https://github.com/openemr/openemr/pull/12007) fix(vitals): drop duplicate growth-chart buttons from Vitals History — @kojiromike
+- [#12189](https://github.com/openemr/openemr/pull/12189) fix: Fix ethnicity decline setting — @adunsulag
+- [#12170](https://github.com/openemr/openemr/pull/12170) fix: bypass max_input_vars truncation in edit_layout and edit_payment — @progradedteam-dev
+- [#12224](https://github.com/openemr/openemr/pull/12224) fix(faxsms): lazy-init AppDispatch session to survive static factory path — @kojiromike
+- [#12223](https://github.com/openemr/openemr/pull/12223) fix(edihistory): move use statement out of docblock — @stephenwaite
+- [#11868](https://github.com/openemr/openemr/pull/11868) fix(billing): cast 835 monetary fields to float for type-strict comparisons — @stephenwaite
+- [#12194](https://github.com/openemr/openemr/pull/12194) fix(upgrade): normalize categories_seq instead of unsafe multi-row UP… — @stephenwaite
+- [#11691](https://github.com/openemr/openemr/pull/11691) fix(billing): session crashes on posting page — @stephenwaite
+- [#12188](https://github.com/openemr/openemr/pull/12188) fix: Fix ethnicity decline setting — @adunsulag
+- [#12186](https://github.com/openemr/openemr/pull/12186) fix(globals): Restore windows webserver_root normalization. (#12140) — @kojiromike
+- [#12011](https://github.com/openemr/openemr/pull/12011) fix(upgrade): drop redundant categories_seq UPDATE in eye form laser migration — @stephenwaite
+- [#12140](https://github.com/openemr/openemr/pull/12140) fix(globals): Restore windows webserver_root normalization. — @sjpadgett
+- [#12144](https://github.com/openemr/openemr/pull/12144) fix(portal): correct deleteItem target and readMessage issue — @techaround
+- [#11949](https://github.com/openemr/openemr/pull/11949) fix(login): default login_page_layout when globals row is missing — @kojiromike
+- [#12083](https://github.com/openemr/openemr/pull/12083) fix(patient): dispatch PatientCreatedEvent from legacy new_patient_save.php — @kojiromike
+- [#12050](https://github.com/openemr/openemr/pull/12050) fix(faxsms): use filesystem-targeted encryption for cached auth — @Firehed
+- [#12031](https://github.com/openemr/openemr/pull/12031) fix(billing): add CSRF check + tighten input on fee_sheet review/justify — @kojiromike
+- [#12019](https://github.com/openemr/openemr/pull/12019) fix(sql): handle table-qualified columns in escape_sql_column_name() — @Firehed
+- [#12018](https://github.com/openemr/openemr/pull/12018) fix(security): physical_exam edit_diagnoses ACL gate is dead code — @kojiromike
+- [#11551](https://github.com/openemr/openemr/pull/11551) fix(security): use DOM construction for iframe in twAddFrameTab — @kojiromike
+- [#11601](https://github.com/openemr/openemr/pull/11601) fix(cda): register-conditional list XPath in CdaTextParser — @haoyu-haoyu
+- [#11603](https://github.com/openemr/openemr/pull/11603) fix(tests): Remove error-suppressing catch block — @Firehed
+- [#11615](https://github.com/openemr/openemr/pull/11615) fix(ci): Detect PHPUnit exiting without finishing — @Firehed
+- [#11620](https://github.com/openemr/openemr/pull/11620) fix(ci): match runner Node version to nginx container — @kojiromike
+- [#11647](https://github.com/openemr/openemr/pull/11647) fix(php85): resolve deprecations in services test suite — @kojiromike
+- [#11680](https://github.com/openemr/openemr/pull/11680) fix(medex): decouple background service from legacy AJAX entry point — @kojiromike
+- [#11688](https://github.com/openemr/openemr/pull/11688) fix(mailer): hardcode UTF-8 CharSet to avoid null from missing global — @kojiromike
+- [#11690](https://github.com/openemr/openemr/pull/11690) fix(db): use tinyint(1) for questionnaire_repository.active boolean — @Firehed
+- [#11693](https://github.com/openemr/openemr/pull/11693) fix(installer): require igroup field during installation — @Firehed
+- [#11700](https://github.com/openemr/openemr/pull/11700) fix(orm): fix multiple bugs in ORDataObject::_load_enum — @Firehed
+- [#11728](https://github.com/openemr/openemr/pull/11728) fix(ci): prevent cross-Node-version cache contamination in test workflow — @kojiromike
+- [#11735](https://github.com/openemr/openemr/pull/11735) fix(local-api): bootstrap missing user UUID to prevent 500 on fresh installs — @kojiromike
+- [#11755](https://github.com/openemr/openemr/pull/11755) fix(e2e): wait for post-login title transition to avoid race — @kojiromike
+- [#11756](https://github.com/openemr/openemr/pull/11756) fix(ci): gate openemr on mysql service_healthy to avoid race — @kojiromike
+- [#11767](https://github.com/openemr/openemr/pull/11767) fix(docker): remove obsolete --with-pic from dev-php-fpm 8.6 build — @kojiromike
+- [#11802](https://github.com/openemr/openemr/pull/11802) fix(phpstan): drain file-not-found baseline entries — @kojiromike
+- [#11803](https://github.com/openemr/openemr/pull/11803) fix(deps): sync package-lock.json with xmldom 0.9.10 update — @Firehed
+- [#11813](https://github.com/openemr/openemr/pull/11813) fix(phpstan): drain function-not-found baseline entries — @kojiromike
+- [#11858](https://github.com/openemr/openemr/pull/11858) fix(e2e): capture diagnostics for user-add modal timeout flake — @kojiromike
+- [#11864](https://github.com/openemr/openemr/pull/11864) fix(db): Log all "helpfuldie" sql errors — @Firehed
+- [#11866](https://github.com/openemr/openemr/pull/11866) fix(db): Fix SQL upgrade syntax — @Firehed
+- [#11876](https://github.com/openemr/openemr/pull/11876) fix(db): convert declne_to_specfy in patient_data language and ethnicity — @kojiromike
+- [#11877](https://github.com/openemr/openemr/pull/11877) fix(portal): drain PHPStan class.notFound baseline for portal/patient — @kojiromike
+- [#11882](https://github.com/openemr/openemr/pull/11882) fix(rx): set linkMethod for Ensora eRx prescription button — @kojiromike
+- [#11883](https://github.com/openemr/openemr/pull/11883) fix(encounter): handle missing row and null uuid in encounter view form — @kojiromike
+- [#11888](https://github.com/openemr/openemr/pull/11888) fix(csrf): stop rotating CSRF private key on every main_screen.php load — @kojiromike
+- [#11897](https://github.com/openemr/openemr/pull/11897) fix(ci): Inferno testsuite setup fixes — @Firehed
+- [#11906](https://github.com/openemr/openemr/pull/11906) fix(sql): Allow sql_upgrade to work on the cli — @Firehed
+- [#11907](https://github.com/openemr/openemr/pull/11907) fix(faxsms): catch up missed appointment-reminder ticks — @kojiromike
+- [#11909](https://github.com/openemr/openemr/pull/11909) fix(ci): Turn off redis persistence in inferno tests — @Firehed
+- [#11916](https://github.com/openemr/openemr/pull/11916) fix(ci): add NPI to user to qualify as Practitioner in Inferno tests — @Firehed
+- [#11917](https://github.com/openemr/openemr/pull/11917) fix(test): correct Inferno test group IDs for body height/weight — @Firehed
+- [#11922](https://github.com/openemr/openemr/pull/11922) fix(faxsms): require appointments lib; log background-service errors — @kojiromike
+- [#11937](https://github.com/openemr/openemr/pull/11937) fix(clinical-notes): correct i18formatting asset name typo — @kojiromike
+- [#11939](https://github.com/openemr/openemr/pull/11939) fix: guard undefined keys and legacy PHP warnings flagged in production logs — @kojiromike
+- [#11947](https://github.com/openemr/openemr/pull/11947) fix(main-tabs): restore default tab loading after login — @kojiromike
+- [#11951](https://github.com/openemr/openemr/pull/11951) fix(security): validate db parameter in standard_tables_manage — @kojiromike
+- [#11953](https://github.com/openemr/openemr/pull/11953) fix(session): restore brief-lock pattern on long-running pages — @kojiromike
+- [#11958](https://github.com/openemr/openemr/pull/11958) fix(portal): add CSRF protection to payment handler — @Firehed
+- [#11959](https://github.com/openemr/openemr/pull/11959) fix(ci): Run additional web workers in API integration tests — @Firehed
+- [#11962](https://github.com/openemr/openemr/pull/11962) fix(faxsms): tighten oe_faxsms_queue schema for utf8mb4 compatibility — @kojiromike
+- [#11972](https://github.com/openemr/openemr/pull/11972) fix(auth): remove unused redirect_token from OneTimeAuth — @Firehed
+- [#11983](https://github.com/openemr/openemr/pull/11983) fix(ci): disable patient birthday alert in e2e compose stack — @kojiromike
+- [#11985](https://github.com/openemr/openemr/pull/11985) fix(care-plan): unify blank-row template through foreach — @kojiromike
+- [#11999](https://github.com/openemr/openemr/pull/11999) fix(ui): Fix crash from uncaught class in birthday popup — @Firehed
+- [#11976](https://github.com/openemr/openemr/pull/11976) fix(vitals): growth chart fatals on missing patient sex; drain variable.undefined — @haoyu-haoyu
+- [#10762](https://github.com/openemr/openemr/pull/10762) fix(db): rename misspelled 'declne_to_specfy' value in race — @phantom930
+- [#11987](https://github.com/openemr/openemr/pull/11987) fix(encounter): use getBoolean for inhouse_pharmacy check in visit summary — @kojiromike
+- [#11940](https://github.com/openemr/openemr/pull/11940) fix(session): clean up callers that re-open read_and_close session — @kojiromike
+- [#8087](https://github.com/openemr/openemr/pull/8087) fix: clinicians can edit medications — @stephenwaite
+- [#11618](https://github.com/openemr/openemr/pull/11618) fix(bootstrap): replace die() with exception for missing session site_id — @kojiromike
+- [#11948](https://github.com/openemr/openemr/pull/11948) fix(background-services): resolve PHP CLI binary via PhpExecutableFinder — @kojiromike
+- [#11846](https://github.com/openemr/openemr/pull/11846) fix(faxsms): surface notification background-task failures — @kojiromike
+- [#11904](https://github.com/openemr/openemr/pull/11904) fix(phpdoc): repair legacy parse errors across the codebase — @kojiromike
+- [#11807](https://github.com/openemr/openemr/pull/11807) fix(smarty): save admin practice practice settings — @stephenwaite
+- [#11547](https://github.com/openemr/openemr/pull/11547) fix(ci): simplify Codecov flags to fix "Multiple flags detected" error — @Firehed
+- [#11801](https://github.com/openemr/openemr/pull/11801) fix(background-services): isolate run-all-due behind subprocess boundary — @kojiromike
+- [#11245](https://github.com/openemr/openemr/pull/11245) fix(calendar): remove 0000-00-00 date defaults from postcalendar events — @Firehed
+- [#10511](https://github.com/openemr/openemr/pull/10511) fix(deprecations): Comlink module — @juggernautsei
+- [#11678](https://github.com/openemr/openemr/pull/11678) fix(background-services): recover stuck leases from crashed workers — @kojiromike
+- [#11625](https://github.com/openemr/openemr/pull/11625) fix(encounter): fix saving in collection on auto create encounter — @stephenwaite
+- [#11407](https://github.com/openemr/openemr/pull/11407) fix(calendar): route freq_type 5 to REPEAT_ON branch to prevent infin… — @stephenwaite
+- [#11442](https://github.com/openemr/openemr/pull/11442) fix(security): centralize XML parsing to enforce LIBXML_NONET across all call sites — @craigrallen
+- [#11091](https://github.com/openemr/openemr/pull/11091) fix(security): add ACL check to claim file tracker endpoint — @kojiromike
+- [#11090](https://github.com/openemr/openemr/pull/11090) fix(security): prevent XSS in portal signer modal — @kojiromike
+- [#11089](https://github.com/openemr/openemr/pull/11089) fix(security): prevent XSS in clickmap annotation legend — @kojiromike
+- [#11019](https://github.com/openemr/openemr/pull/11019) fix(auth): correct assignment typo in AuthHash SHA512 fallback — @Copilot
+- [#11008](https://github.com/openemr/openemr/pull/11008) fix: Remove accidental override of OEGlobalsBag::getString — @Copilot
+- [#10849](https://github.com/openemr/openemr/pull/10849) fix(db): set uor=0 for deprecated care_team layout fields — @Copilot
+- [#11211](https://github.com/openemr/openemr/pull/11211) fix(schema): correct empty string in list_options integer columns — @Firehed
+- [#11130](https://github.com/openemr/openemr/pull/11130) fix(logging): SystemLogger PSR-3 compliance and simplification — @Firehed
+- [#11097](https://github.com/openemr/openemr/pull/11097) fix(security): check sensitivity from correct table for group encounters — @kojiromike
+- [#11094](https://github.com/openemr/openemr/pull/11094) fix(security): negate ACL condition in CDR ControllerRouter — @kojiromike
+- [#11096](https://github.com/openemr/openemr/pull/11096) fix(security): escape code descriptions in dynamic code picker — @kojiromike
+- [#11093](https://github.com/openemr/openemr/pull/11093) fix(security): remove user input from SQL alias in graphs — @kojiromike
+- [#11095](https://github.com/openemr/openemr/pull/11095) fix(security): escape Track Anything graph titles and labels — @kojiromike
+- [#11092](https://github.com/openemr/openemr/pull/11092) fix(security): escape patient data in prescription print view — @kojiromike
+- [#11418](https://github.com/openemr/openemr/pull/11418) fix(calendar): Render restoreSession JS inside of script tag — @Firehed
+- [#11503](https://github.com/openemr/openemr/pull/11503) fix: Fixes #11161 #11492 encounter nav issues — @adunsulag
+- [#11347](https://github.com/openemr/openemr/pull/11347) fix(security): replace addslashes() with js_escape() in JS contexts — @haoyu-haoyu
+- [#11372](https://github.com/openemr/openemr/pull/11372) fix(tests): add integration tests to phpunit.xml and CI suite list — @haoyu-haoyu
+- [#11485](https://github.com/openemr/openemr/pull/11485) fix(documents): view document from past encounters for rel-800 — @stephenwaite
+- [#11597](https://github.com/openemr/openemr/pull/11597) fix(security): validate formdir before using in include paths — @kojiromike
+- [#11589](https://github.com/openemr/openemr/pull/11589) fix(faxsms): stop overwriting pc_apptstatus during notification dedup — @kojiromike
+- [#11592](https://github.com/openemr/openemr/pull/11592) fix(security): validate require_once paths loaded from database — @kojiromike
+- [#11588](https://github.com/openemr/openemr/pull/11588) fix(faxsms): dedup recurring appointment notifications via notification_log — @kojiromike
+- [#11587](https://github.com/openemr/openemr/pull/11587) fix(faxsms): read cron interval from background_services instead of hardcoding 150 — @kojiromike
+- [#10896](https://github.com/openemr/openemr/pull/10896) fix(security): add allowed_classes to unprotected unserialize calls — @craigrallen
+- [#11504](https://github.com/openemr/openemr/pull/11504) fix: Fixes #11493 observation form report embed fix — @adunsulag
+- [#11511](https://github.com/openemr/openemr/pull/11511) fix(install): use newline separator in SQL statement concatenation — @haoyu-haoyu
+- [#11513](https://github.com/openemr/openemr/pull/11513) fix(security): validate menu role filenames to prevent path traversal — @haoyu-haoyu
+- [#10901](https://github.com/openemr/openemr/pull/10901) fix(api): fix per-patient allergy and condition endpoints returning empty (#10827) — @craigrallen
+- [#11509](https://github.com/openemr/openemr/pull/11509) fix(faxsms): use 24-hour clock for notification window math — @haoyu-haoyu
+- [#11510](https://github.com/openemr/openemr/pull/11510) fix(eye-mag): use correct PMSFH key for PMH diagnoses in Diagnosis Builder — @haoyu-haoyu
+- [#11499](https://github.com/openemr/openemr/pull/11499) fix(cpt4): skip UPDATE when CPT4 code lookup returns empty — @haoyu-haoyu
+- [#11430](https://github.com/openemr/openemr/pull/11430) fix(config): stop suppressing E_USER_WARNING and E_USER_DEPRECATED — @haoyu-haoyu
+- [#11363](https://github.com/openemr/openemr/pull/11363) fix(csv): replace addslashes() with RFC 4180 CSV double-quote escaping — @haoyu-haoyu
+- [#11291](https://github.com/openemr/openemr/pull/11291) fix: Fix clinical notes date formatting (Fixes #11290). — @adunsulag
+- [#11300](https://github.com/openemr/openemr/pull/11300) fix(e2e): resolve flaky User add test under coverage — @kojiromike
+- [#11331](https://github.com/openemr/openemr/pull/11331) fix(background-services): fix OPENEMR__NO_BACKGROUND_TASKS env var reliability and scope — @kojiromike
+- [#11396](https://github.com/openemr/openemr/pull/11396) fix(portal): remove dead $payment_key code in portal_payment.php — @Copilot
+- [#11169](https://github.com/openemr/openemr/pull/11169) fix: Fixes #11142 employer data not saving (#11156) — @adunsulag
+- [#11383](https://github.com/openemr/openemr/pull/11383) fix(menu): sync Custom.json with standard.json for email send test entry — @kojiromike
+- [#11362](https://github.com/openemr/openemr/pull/11362) fix(phpstan): emit ADOdb-accurate types in TableTypes generator — @kojiromike
+- [#11388](https://github.com/openemr/openemr/pull/11388) fix(security): add LIBXML_NONET to all simplexml_load_string calls — @Copilot
+- [#11420](https://github.com/openemr/openemr/pull/11420) fix(hooks): read commit message content instead of file path — @kojiromike
+- [#11450](https://github.com/openemr/openemr/pull/11450) fix(payments): post payment from portal in portal dash — @stephenwaite
+- [#11455](https://github.com/openemr/openemr/pull/11455) fix(phpstan): correct misleading docblock @return/@param types — @kojiromike
+- [#11484](https://github.com/openemr/openemr/pull/11484) fix(faxsms): stop resending appointment reminder emails every hour — @kojiromike
+- [#11515](https://github.com/openemr/openemr/pull/11515) fix(cdr): stop translating DB identifiers in render_select — @haoyu-haoyu
+- [#11466](https://github.com/openemr/openemr/pull/11466) fix(sql-upgrade): drop fgets() length limit and insert line separator — @kojiromike
+- [#11470](https://github.com/openemr/openemr/pull/11470) fix(direct-messaging): drop fgets() length limits in phiMail protocol parsers — @kojiromike
+- [#11500](https://github.com/openemr/openemr/pull/11500) fix(translation): use unconditional xl() for dynamic strings, not xl_list_label — @kojiromike
+- [#11502](https://github.com/openemr/openemr/pull/11502) fix(db): Change OSCONJ column type on form_eye_antseg table — @margarethaywood
+- [#11512](https://github.com/openemr/openemr/pull/11512) fix(security): escape tab label in TabsWrapper to prevent XSS — @haoyu-haoyu
+- [#11543](https://github.com/openemr/openemr/pull/11543) fix(deps): resolve Dependabot overlapping directory error — @kojiromike
+- [#11150](https://github.com/openemr/openemr/pull/11150) fix(claims): other payer claim control number for secondary claims — @stephenwaite
+- [#11003](https://github.com/openemr/openemr/pull/11003) fix(install): add space separator between SQL lines in load_file() (#10935) — @craigrallen
+- [#11217](https://github.com/openemr/openemr/pull/11217) fix(security): prevent open redirect in portal messaging — @haoyu-haoyu
+- [#11072](https://github.com/openemr/openemr/pull/11072) fix(session): respect sessionAllowWrite global in PHPSessionWrapper (#10931) — @abishop1990
+- [#10651](https://github.com/openemr/openemr/pull/10651) fix: Add missing $form_return variable assignment in eye_mag save.php — @Copilot
+- [#11061](https://github.com/openemr/openemr/pull/11061) fix: selenium dependabot updates for development-easy-redis — @bradymiller
+- [#11188](https://github.com/openemr/openemr/pull/11188) fix(security): validate DICOM zip entry paths — @kojiromike
+- [#11189](https://github.com/openemr/openemr/pull/11189) fix(security): enforce encounter ownership on vitals — @kojiromike
+- [#11059](https://github.com/openemr/openemr/pull/11059) fix: set production docker-compose.yml to use latest tag on master branch — @bradymiller
+- [#11288](https://github.com/openemr/openemr/pull/11288) fix(database): resolve PHP 8.5 PDO MySQL attribute deprecations — @Firehed
+- [#10977](https://github.com/openemr/openemr/pull/10977) fix: Revert prior predis 3.4.0 fix — @bradymiller
+- [#11282](https://github.com/openemr/openemr/pull/11282) fix(database): Ensure legacy DB connection is established — @Firehed
+- [#11004](https://github.com/openemr/openemr/pull/11004) fix(messages): replace misleading unauthorized template with silent return (#10686) — @craigrallen
+- [#11251](https://github.com/openemr/openemr/pull/11251) fix(schema): remove 0000-00-00 values from document_templates inserts — @Firehed
+- [#10999](https://github.com/openemr/openemr/pull/10999) fix(docs): correct spelling errors caught by codespell — @Firehed
+- [#10664](https://github.com/openemr/openemr/pull/10664) fix(sql): wrap scalar values in arrays for SQL function params — @Firehed
+- [#11007](https://github.com/openemr/openemr/pull/11007) fix(phpstan): add types and fix errors in ClientAdminController — @kojiromike
+- [#10998](https://github.com/openemr/openemr/pull/10998) fix(db): remove dynamically created onsite_activity_view — @Firehed
+- [#10939](https://github.com/openemr/openemr/pull/10939) fix(session): replace direct $_SESSION writes with SessionUtil::setSession() — @kojiromike
+- [#11246](https://github.com/openemr/openemr/pull/11246) fix(ci): quote time values in dependabot.yml — @kojiromike
+- [#11220](https://github.com/openemr/openemr/pull/11220) fix(security): parameterize all SQL in deleter.php via root-cause refactor — @haoyu-haoyu
+- [#11156](https://github.com/openemr/openemr/pull/11156) fix: Fixes #11142 employer data not saving — @adunsulag
+- [#10869](https://github.com/openemr/openemr/pull/10869) fix: use https in @link header tags — @kojiromike
+- [#10685](https://github.com/openemr/openemr/pull/10685) fix(e2e): handle duplicate visit alert immediately after menu click — @kojiromike
+- [#11218](https://github.com/openemr/openemr/pull/11218) fix(security): parameterize SQL, add CSRF, and fix serialization injection in portal appointment — @haoyu-haoyu
+- [#11212](https://github.com/openemr/openemr/pull/11212) fix(schema): use CURRENT_TIMESTAMP default for medex_recalls.r_created — @Firehed
+- [#11219](https://github.com/openemr/openemr/pull/11219) fix(security): add CSRF protection and parameterize SQL in new_payment.php — @haoyu-haoyu
+- [#11216](https://github.com/openemr/openemr/pull/11216) fix(security): parameterize SQL, remove dead code, and migrate to QueryUtils in pnotes.inc.php — @haoyu-haoyu
+- [#11210](https://github.com/openemr/openemr/pull/11210) fix(schema): reduce onetime_auth index prefix length — @Firehed
+- [#11215](https://github.com/openemr/openemr/pull/11215) fix(portal): portal messaging display fix for #11202 — @zmilan
+- [#10988](https://github.com/openemr/openemr/pull/10988) fix(i18n): correct "Dislay" typo in main menu logo description — @kojiromike
+- [#11208](https://github.com/openemr/openemr/pull/11208) fix(session): fix leftovers from porting core session — @zmilan
+- [#11166](https://github.com/openemr/openemr/pull/11166) fix(composer): use forward slashes in autoload-dev path — @kojiromike
+- [#10824](https://github.com/openemr/openemr/pull/10824) fix(api): include provider first/last name in appointment API responses — @fzzio
+- [#10905](https://github.com/openemr/openemr/pull/10905) fix(ci): prevent PHPStan pre-commit hook baseline mismatch (#10868) — @craigrallen
+- [#11111](https://github.com/openemr/openemr/pull/11111) fix(install): remove OEGlobalsBag dependency from sql_upgrade.php — @kojiromike
+- [#10856](https://github.com/openemr/openemr/pull/10856) fix(predis): predis 3.4.0 fix — @bradymiller
+- [#10899](https://github.com/openemr/openemr/pull/10899) fix(sql): qualify column reference in CareTeamService::getCareTeamData() — @craigrallen
+- [#10804](https://github.com/openemr/openemr/pull/10804) fix(phpstan): fix invalid return type annotations — @Firehed
+- [#10888](https://github.com/openemr/openemr/pull/10888) fix(oauth2): create certificates directory before writing key files — @kojiromike
+- [#10822](https://github.com/openemr/openemr/pull/10822) fix(api): use isPortalRequest() for portal route detection in RoutesExtensionListener — @fzzio
+- [#10871](https://github.com/openemr/openemr/pull/10871) fix(ci): rector cache masks violations on unchanged files — @kojiromike
+- [#11146](https://github.com/openemr/openemr/pull/11146) fix(reports): include custom LBF layout forms in patient report — @pradhankukiran
+- [#10839](https://github.com/openemr/openemr/pull/10839) fix(semgrep): add generate_select_list and json_encode as sanitizers — @kojiromike
+- [#11134](https://github.com/openemr/openemr/pull/11134) fix(upgrade): disable audit logging before globals.php loads — @kojiromike
+- [#10814](https://github.com/openemr/openemr/pull/10814) fix(eye-mag): correct Schirmer field name typos in copy_forward ANTSEG zone — @danielalanbates
+- [#11214](https://github.com/openemr/openemr/pull/11214) fix(security): parameterize SQL in patient.inc.php and harden column name escaping — @haoyu-haoyu
+- [#10799](https://github.com/openemr/openemr/pull/10799) fix(e2e): handle UnexpectedAlertOpenException in assertActiveTab — @kojiromike
+- [#11199](https://github.com/openemr/openemr/pull/11199) fix(security): parameterize SQL and filter request inputs in add_edit_event — @haoyu-haoyu
+- [#11194](https://github.com/openemr/openemr/pull/11194) fix(security): escape inline script values in portal payment — @kojiromike
+- [#11193](https://github.com/openemr/openemr/pull/11193) fix(security): add authorization to FaxSMS AppDispatch — @kojiromike
+- [#11192](https://github.com/openemr/openemr/pull/11192) fix(security): add authorization to dated reminders log — @kojiromike
+- [#11191](https://github.com/openemr/openemr/pull/11191) fix(security): escape portal credential print output — @kojiromike
+- [#11190](https://github.com/openemr/openemr/pull/11190) fix(security): sanitize SearchHighlight input — @kojiromike
+- [#11187](https://github.com/openemr/openemr/pull/11187) fix(security): respect explicit ACL denies in zhAclCheck — @kojiromike
+- [#11186](https://github.com/openemr/openemr/pull/11186) fix(security): escape user data in Eye Exam report — @kojiromike
+- [#11185](https://github.com/openemr/openemr/pull/11185) fix(security): sanitize backup export command arguments — @kojiromike
+- [#10765](https://github.com/openemr/openemr/pull/10765) fix(e2e): add CI full test mode and fix stale element in assertActiveTab — @kojiromike
+- [#10703](https://github.com/openemr/openemr/pull/10703) fix(phpstan): Fail if baseline doesn't match generator — @Firehed
+- [#11155](https://github.com/openemr/openemr/pull/11155) fix(documents): separate password from encryption for C_Document.clas… — @stephenwaite
+- [#10749](https://github.com/openemr/openemr/pull/10749) fix(e2e): wait for active tab element before checking content — @kojiromike
+- [#10791](https://github.com/openemr/openemr/pull/10791) fix(phpstan): correct custom rule implementations — @Firehed
+- [#10760](https://github.com/openemr/openemr/pull/10760) fix(claimrev): add mailto: protocol to email links — @kojiromike
+- [#10758](https://github.com/openemr/openemr/pull/10758) fix(claimrev): add input validation for ERA ID parameter — @kojiromike
+- [#10891](https://github.com/openemr/openemr/pull/10891) fix(search): wrap DATETIME empty-string comparisons with CAST — @kojiromike
+- [#11163](https://github.com/openemr/openemr/pull/11163) fix(controller): add order-independent routing via dispatch() method — @kojiromike
+- [#10846](https://github.com/openemr/openemr/pull/10846) fix(db): rename misspelled 'interpretter' column to 'interpreter' — @jbaiad
+- [#11144](https://github.com/openemr/openemr/pull/11144) fix(encounter): hide dispensed medications section when inhouse_pharmacy is disabled — @pradhankukiran
+- [#11053](https://github.com/openemr/openemr/pull/11053) fix: remove OEGlobalsBag dependency from version.php — @kojiromike
+- [#10985](https://github.com/openemr/openemr/pull/10985) fix(appt): avoid HTML-encoded status text in demographics widgets — @craigrallen
+- [#10983](https://github.com/openemr/openemr/pull/10983) fix(i18n): apply xlt filter in patient verify success email templates — @craigrallen
+- [#10993](https://github.com/openemr/openemr/pull/10993) fix(api): align allergy begdate validation with YYYY-MM-DD docs — @craigrallen
+- [#10991](https://github.com/openemr/openemr/pull/10991) fix(encounter): enforce newest-first sort in encounters report — @craigrallen
+- [#10984](https://github.com/openemr/openemr/pull/10984) fix(apptstat): accept #RRGGBB in status color field — @craigrallen
+- [#10949](https://github.com/openemr/openemr/pull/10949) fix(sdoh): add missing site parameter to SDOH assessment URLs — @Boykosoft
+- [#10895](https://github.com/openemr/openemr/pull/10895) fix(security): protect bin/ directory from web access — @craigrallen
+- [#10851](https://github.com/openemr/openemr/pull/10851) fix(payments): use theme-stable colors for receipt background contrast — @jbaiad
+- [#10763](https://github.com/openemr/openemr/pull/10763) fix(claimrev): use $postData parameter instead of $_POST — @kojiromike
+- [#10759](https://github.com/openemr/openemr/pull/10759) fix(claimrev): replace hardcoded dev URLs with configurable settings — @kojiromike
+- [#10733](https://github.com/openemr/openemr/pull/10733) fix(lbf): respect default value for checkboxes — @kojiromike
+- [#10756](https://github.com/openemr/openemr/pull/10756) fix(claimrev): validate required settings in isConfigured() — @kojiromike
+- [#10757](https://github.com/openemr/openemr/pull/10757) fix(claimrev): restrict file permissions for EDI downloads — @kojiromike
+- [#10752](https://github.com/openemr/openemr/pull/10752) fix(claimrev): throw exceptions on API failures instead of returning error values — @kojiromike
+- [#10647](https://github.com/openemr/openemr/pull/10647) fix(demographics): hide appointments card when user lacks permission — @kojiromike
+- [#10755](https://github.com/openemr/openemr/pull/10755) fix(modules): remove dead methods referencing undefined constants — @kojiromike
+- [#10754](https://github.com/openemr/openemr/pull/10754) fix(claimrev): prevent HTML escaping of ERA file downloads — @kojiromike
+- [#10728](https://github.com/openemr/openemr/pull/10728) fix(billing): create ERA directory and add overwrite confirmation — @kojiromike
+- [#10644](https://github.com/openemr/openemr/pull/10644) fix(patient): detect duplicates when lower-PID patient matches higher-PID — @kojiromike
+- [#10652](https://github.com/openemr/openemr/pull/10652) fix(e2e): add diagnostics and retry for modal close timeout in testUserAdd — @kojiromike
+- [#10661](https://github.com/openemr/openemr/pull/10661) fix(payments): SQL Query Error: Column 'session_id' cannot be null — @stephenwaite
+- [#10788](https://github.com/openemr/openemr/pull/10788) fix(labs): PHP warnings interface/orders — @stephenwaite
+- [#7667](https://github.com/openemr/openemr/pull/7667) fix(patient): set portal login username when enabling portal access — @ruthkonyn
+- [#11115](https://github.com/openemr/openemr/pull/11115) fix: preserve patient context in EHR launch skip-auth flow — @mattpolly
+- [#11381](https://github.com/openemr/openemr/pull/11381) fix(email): remove SMTP_SECURE from isConfigured required keys — @kojiromike
+- [#11297](https://github.com/openemr/openemr/pull/11297) fix(security): harden escape_table_name() with backtick-quoting — @kojiromike
+- [#11280](https://github.com/openemr/openemr/pull/11280) fix(security): harden escape_sql_column_name() with backtick-quoting — @kojiromike
+- [#10894](https://github.com/openemr/openemr/pull/10894) fix(eye): add state license number to prescription popup — @stephenwaite
+- [#10882](https://github.com/openemr/openemr/pull/10882) fix(eye): Dispense glasses Rx: manifest/dispensed refraction — @stephenwaite
+- [#11198](https://github.com/openemr/openemr/pull/11198) fix(users): allow clearing email field in user admin update — @rollingventures
+- [#10937](https://github.com/openemr/openemr/pull/10937) fix(search): wrap DATETIME empty-string comparisons with CAST (#10891) for rel-800 — @stephenwaite
+- [#10865](https://github.com/openemr/openemr/pull/10865) fix(eyeform): pass encounter/pid in navbar form URLs to prevent stale session — @jbaiad
+- [#10908](https://github.com/openemr/openemr/pull/10908) fix(ci): detect database.sql schema changes missing upgrade SQL (#10854) — @craigrallen
+- [#10903](https://github.com/openemr/openemr/pull/10903) fix(security): add CSV formula escaping to League\Csv exports (#10415) — @craigrallen
+- [#10902](https://github.com/openemr/openemr/pull/10902) fix(security): remove eval() from application JavaScript files (#2010) — @craigrallen
+- [#10922](https://github.com/openemr/openemr/pull/10922) fix(test): make dupscore unique-flag test robust against demo data — @jbaiad
+- [#10909](https://github.com/openemr/openemr/pull/10909) fix(ci): ensure xdebug.mode=coverage for PHPUnit test file coverage (#10687) — @craigrallen
+- [#10557](https://github.com/openemr/openemr/pull/10557) fix(recalls): improve recall board filtering and form validation — @kojiromike
+- [#10897](https://github.com/openemr/openemr/pull/10897) fix(security): add safe_href URL scheme validation for Twig href attributes — @craigrallen
+- [#10823](https://github.com/openemr/openemr/pull/10823) fix(api): pass HttpRestRequest to PatientRestController::getOne() in portal route — @fzzio
+- [#10813](https://github.com/openemr/openemr/pull/10813) fix(database): return falsy column values from fetchSingleValue instead of null — @danielalanbates
+- [#10830](https://github.com/openemr/openemr/pull/10830) fix(ehi-export): initialize variables in createExportTasksFromJobWith… — @robinson-j16
+- [#10772](https://github.com/openemr/openemr/pull/10772) fix(phone): Use correct locale-aware formatting for phone number display — @evolvomind
+- [#10750](https://github.com/openemr/openemr/pull/10750) fix(claimrev): save all subscribers in eligibility request — @kojiromike
+- [#10663](https://github.com/openemr/openemr/pull/10663) fix(sql): Error: Object of class Closure could not be converted to st… — @stephenwaite
+- [#10698](https://github.com/openemr/openemr/pull/10698) fix: rename 'uncomplete' mode to 'incomplete' in AMC tracking — @evolvomind
+- [#10693](https://github.com/openemr/openemr/pull/10693) fix(phpstan): add @var annotations to reduce variable.undefined baseline — @Firehed
+- [#10680](https://github.com/openemr/openemr/pull/10680) fix(erx): allow allergy entry without eRx role — @kojiromike
+- [#10677](https://github.com/openemr/openemr/pull/10677) fix(ci): add path fixes for Codecov coverage reports — @kojiromike
+- [#10464](https://github.com/openemr/openemr/pull/10464) fix(qrda): use escaped Mustache variables in XML attribute positions — @kojiromike
+- [#10673](https://github.com/openemr/openemr/pull/10673) fix: SingletonTrait — @igormukhingmailcom
+- [#10672](https://github.com/openemr/openemr/pull/10672) fix(pre-commit): exclude PHPStan baseline files from analysis hooks — @Copilot
+- [#10636](https://github.com/openemr/openemr/pull/10636) fix(zend): include port in PDO DSN for non-default database ports — @kojiromike
+
+## Refactoring
+
+- [#12699](https://github.com/openemr/openemr/pull/12699) refactor(audit): Update audit logger sql path to be DI-friendly — @Firehed
+- [#12526](https://github.com/openemr/openemr/pull/12526) refactor(oe-module-faxsms): Fix SignalWire fax support in oe-module-faxsms — @sjpadgett
+- [#12766](https://github.com/openemr/openemr/pull/12766) refactor(oe-module-faxsms): Fix SignalWire fax support in oe-module-faxsms — @bradymiller
+- [#12763](https://github.com/openemr/openemr/pull/12763) refactor(globals): Integrate OEGlobalsBag key deprecation tooling — @Firehed
+- [#12689](https://github.com/openemr/openemr/pull/12689) refactor(session): Adopt DTO for settings & tidy cookie path — @Firehed
+- [#12698](https://github.com/openemr/openemr/pull/12698) refactor(audit): Centralize and simplify "should log" logic — @Firehed
+- [#12655](https://github.com/openemr/openemr/pull/12655) refactor(audit): Add multi-sink destination — @Firehed
+- [#12633](https://github.com/openemr/openemr/pull/12633) refactor(db): Move doctrine/migrations config — @Firehed
+- [#12590](https://github.com/openemr/openemr/pull/12590) refactor(ci): relocate docker/compose.yml to .github/docker/ — @bradymiller
+- [#12578](https://github.com/openemr/openemr/pull/12578) refactor(ci): extract sync-byte-identical bash into a tested script — @bradymiller
+- [#12576](https://github.com/openemr/openemr/pull/12576) refactor(ci): trim docker/.gitignore + docker/COVERAGE.md from byte-identical set — @bradymiller
+- [#12575](https://github.com/openemr/openemr/pull/12575) refactor(ci): externalize byte-identical FILES_ALL to a dedicated config file — @bradymiller
+- [#12510](https://github.com/openemr/openemr/pull/12510) refactor(security): Remove unused client SSL certificate auth feature — @Firehed
+- [#12435](https://github.com/openemr/openemr/pull/12435) refactor(calendar): migrate PostCalendar from Smarty to Twig — @bradymiller
+- [#11521](https://github.com/openemr/openemr/pull/11521) refactor(portal): remove AngularJS from secure_chat and messages — @rollingventures
+- [#12246](https://github.com/openemr/openemr/pull/12246) refactor: replace raw assert() calls with real runtime checks — @kojiromike
+- [#12231](https://github.com/openemr/openemr/pull/12231) refactor(portal): extract PatientPortalLoginController, behavior-preserving — @kojiromike
+- [#12195](https://github.com/openemr/openemr/pull/12195) refactor(holidays): move to src/ services and fix calendar import + N+1 — @kojiromike
+- [#12020](https://github.com/openemr/openemr/pull/12020) refactor(faxsms): remove unimplemented VoiceClient — @Firehed
+- [#12146](https://github.com/openemr/openemr/pull/12146) refactor(ui): replace vendored SearchHighlight.js with vanilla TreeWalker helper — @progradedteam-dev
+- [#12123](https://github.com/openemr/openemr/pull/12123) refactor(audit): Remove redundant encryption from audit log writes — @Firehed
+- [#11956](https://github.com/openemr/openemr/pull/11956) refactor(crypto): migrate call sites to encryptForDatabase/decryptFromDatabase helpers — @Firehed
+- [#12069](https://github.com/openemr/openemr/pull/12069) refactor(sphere): use session storage instead of encryption for payment data — @Firehed
+- [#12066](https://github.com/openemr/openemr/pull/12066) refactor(auth): remove redundant encryption from OneTimeAuth tokens — @Firehed
+- [#12062](https://github.com/openemr/openemr/pull/12062) refactor(portal): remove unnecessary encryption from one-time tokens — @Firehed
+- [#11555](https://github.com/openemr/openemr/pull/11555) refactor(services): add array type to $search parameter — @kojiromike
+- [#11556](https://github.com/openemr/openemr/pull/11556) refactor(phpstan): add LayoutOptionsRow type to TableTypes — @kojiromike
+- [#11557](https://github.com/openemr/openemr/pull/11557) refactor(finder): replace getSearchClass with SearchClass enum — @kojiromike
+- [#11571](https://github.com/openemr/openemr/pull/11571) refactor(ci): modernize auto_prepend.php — @kojiromike
+- [#11583](https://github.com/openemr/openemr/pull/11583) refactor(billing): replace escaped HTML strings in EDI270 with heredoc — @Copilot
+- [#11619](https://github.com/openemr/openemr/pull/11619) refactor: narrow broad exception catches to specific types — @kojiromike
+- [#11682](https://github.com/openemr/openemr/pull/11682) refactor(background-services): migrate module installers to Registry — @kojiromike
+- [#11701](https://github.com/openemr/openemr/pull/11701) refactor(ci): Simplify and speed up the integration test build matrix — @Firehed
+- [#11702](https://github.com/openemr/openemr/pull/11702) refactor(cli): Separate "beta" CLI commands — @Firehed
+- [#11704](https://github.com/openemr/openemr/pull/11704) refactor(logging): Support CipherSuiteInterface in EventAuditLogger — @Firehed
+- [#11707](https://github.com/openemr/openemr/pull/11707) refactor(cli): replace allow_cronjobs.php with Symfony console commands — @kojiromike
+- [#11757](https://github.com/openemr/openemr/pull/11757) refactor(globals): migrate interface/forms path reads to typed Kernel accessors — @kojiromike
+- [#11758](https://github.com/openemr/openemr/pull/11758) refactor(globals): migrate interface/patient_file path reads to typed Kernel accessors — @kojiromike
+- [#11759](https://github.com/openemr/openemr/pull/11759) refactor(globals): migrate interface/modules path reads to typed Kernel accessors — @kojiromike
+- [#11760](https://github.com/openemr/openemr/pull/11760) refactor(globals): migrate interface/reports path reads to typed Kernel accessors — @kojiromike
+- [#11761](https://github.com/openemr/openemr/pull/11761) refactor(globals): migrate remaining interface/ subdirs to typed Kernel path accessors — @kojiromike
+- [#11778](https://github.com/openemr/openemr/pull/11778) refactor(document): extract storage path calculation for testability — @Firehed
+- [#11779](https://github.com/openemr/openemr/pull/11779) refactor(filesystem): Move Smarty and mPDF temp directories to system temp — @Firehed
+- [#11791](https://github.com/openemr/openemr/pull/11791) refactor(globals): clean up stale $GLOBALS references in comments — @kojiromike
+- [#11817](https://github.com/openemr/openemr/pull/11817) refactor(globals): rename 'Default Password Expiration Days' to 'Password Expiration Days' — @kojiromike
+- [#11879](https://github.com/openemr/openemr/pull/11879) refactor(edihistory): lift edih_x12_file to OpenEMR\Billing\EdiHistory\X12File — @kojiromike
+- [#11884](https://github.com/openemr/openemr/pull/11884) refactor: replace literal preg_match prefix/suffix checks with native string functions — @kojiromike
+- [#11895](https://github.com/openemr/openemr/pull/11895) refactor(billing): drain variable.undefined PHPStan baseline entries — @kojiromike
+- [#11860](https://github.com/openemr/openemr/pull/11860) refactor(daysheet): extract DaySheetAggregator from print_daysheet_report_num1 — @kojiromike
+- [#11348](https://github.com/openemr/openemr/pull/11348) refactor(php): route superglobal access through HttpRestRequest in src/ — @haoyu-haoyu
+- [#8587](https://github.com/openemr/openemr/pull/8587) refactor(calendar): remove return/store polymorphism from pnHTML — @kojiromike
+- [#11263](https://github.com/openemr/openemr/pull/11263) refactor(globals): migrate library/ path reads to typed Kernel accessors — @kojiromike
+- [#11727](https://github.com/openemr/openemr/pull/11727) refactor(background-services): migrate main-tab poll to REST API — @kojiromike
+- [#11736](https://github.com/openemr/openemr/pull/11736) refactor(uuid): scope auth-path UUID bootstrap to single row — @kojiromike
+- [#11270](https://github.com/openemr/openemr/pull/11270) refactor(calendar): replace repeat-type if/elseif chain with date arithmetic — @haoyu-haoyu
+- [#11069](https://github.com/openemr/openemr/pull/11069) refactor(audit): Extract ATNA logging — @Firehed
+- [#10883](https://github.com/openemr/openemr/pull/10883) refactor(db): Remove support for secure_sqlconf.php — @Firehed
+- [#11106](https://github.com/openemr/openemr/pull/11106) refactor(logging): Remove remaining dependence on errorLogCaller — @Firehed
+- [#11309](https://github.com/openemr/openemr/pull/11309) refactor(logging): inject PSR Clock into EventAuditLogger — @Firehed
+- [#11318](https://github.com/openemr/openemr/pull/11318) refactor(prescription): add native types to Prescription properties — @kojiromike
+- [#11520](https://github.com/openemr/openemr/pull/11520) refactor(di): Cache service instances in ServiceContainer — @Firehed
+- [#11422](https://github.com/openemr/openemr/pull/11422) refactor(billing): replace exec(unzip) with ZipArchive for ERA file uploads — @mw2000
+- [#11269](https://github.com/openemr/openemr/pull/11269) refactor: reduce PHPStan baseline — QueryUtils, PSR-3 logging, inTransaction — @haoyu-haoyu
+- [#11570](https://github.com/openemr/openemr/pull/11570) refactor(globals): add typed path accessors to Kernel and migrate src/ — @kojiromike
+- [#11067](https://github.com/openemr/openemr/pull/11067) refactor(types): add native types to well-covered source files — @kojiromike
+- [#11371](https://github.com/openemr/openemr/pull/11371) refactor(camos): remove js_escape_protected() -- convert literal escapes at source — @haoyu-haoyu
+- [#11553](https://github.com/openemr/openemr/pull/11553) refactor(faxsms): remove dead variables from notification script — @kojiromike
+- [#11320](https://github.com/openemr/openemr/pull/11320) refactor: use BC\Utilities::isDateEmpty() for zero-date checks — @Firehed
+- [#11349](https://github.com/openemr/openemr/pull/11349) refactor(prescription): parameterize SQL, fix loose comparisons, remove dead code — @haoyu-haoyu
+- [#11302](https://github.com/openemr/openemr/pull/11302) refactor(encryption): Message parser and format tooling — @Firehed
+- [#11305](https://github.com/openemr/openemr/pull/11305) refactor(encryption): Simplify the modern key format handling, prepare for explicit key ids — @Firehed
+- [#11303](https://github.com/openemr/openemr/pull/11303) refactor(encryption): Add keychain component — @Firehed
+- [#11334](https://github.com/openemr/openemr/pull/11334) refactor(background-services): extract orchestration into BackgroundServiceRunner — @kojiromike
+- [#11313](https://github.com/openemr/openemr/pull/11313) refactor(camos): modernize CAMOS form code and eliminate PHPStan baseline entries — @kojiromike
+- [#11423](https://github.com/openemr/openemr/pull/11423) refactor(background-services): distinguish lock failure reasons in BackgroundServiceRunner — @mw2000
+- [#11404](https://github.com/openemr/openemr/pull/11404) refactor(config): replace encrypted more_secure globals with constants — @Firehed
+- [#11336](https://github.com/openemr/openemr/pull/11336) refactor(background-services): add BackgroundServiceRegistry for module registration — @kojiromike
+- [#11414](https://github.com/openemr/openemr/pull/11414) refactor(billing): use symfony/process for print command — @Firehed
+- [#11444](https://github.com/openemr/openemr/pull/11444) refactor(cdr): fix literal-string violations in clinical decision rules — @kojiromike
+- [#11428](https://github.com/openemr/openemr/pull/11428) refactor(core): replace VersionService::asString() with SoftwareVersion DTO — @kojiromike
+- [#11427](https://github.com/openemr/openemr/pull/11427) refactor(calendar): replace hardcoded day/month arrays with int-backed enums — @kojiromike
+- [#11429](https://github.com/openemr/openemr/pull/11429) refactor(fhir): fix literal-string violations in xl/xlt calls — @kojiromike
+- [#11443](https://github.com/openemr/openemr/pull/11443) refactor(eye-mag): fix literal-string violations in xl/xlt/xla calls — @kojiromike
+- [#11454](https://github.com/openemr/openemr/pull/11454) refactor(translation): fix literal-string violations in xl wrappers — @kojiromike
+- [#11457](https://github.com/openemr/openemr/pull/11457) refactor(reports): fix literal-string violations in xl/xlt calls — @kojiromike
+- [#11456](https://github.com/openemr/openemr/pull/11456) refactor(menu): fix literal-string violations in xl/xlt calls — @kojiromike
+- [#11460](https://github.com/openemr/openemr/pull/11460) refactor: fix scattered xl literal-string violations (Part 7, final) — @kojiromike
+- [#11461](https://github.com/openemr/openemr/pull/11461) refactor(install): drop 1024-byte fgets() buffer in Installer::getLine() — @kojiromike
+- [#11476](https://github.com/openemr/openemr/pull/11476) refactor(direct-messaging): wrap phiMail socket lifecycle in try/finally — @kojiromike
+- [#11488](https://github.com/openemr/openemr/pull/11488) refactor(database): migrate sqlBeginTrans call sites to QueryUtils::inTransaction — @kojiromike
+- [#10847](https://github.com/openemr/openemr/pull/10847) refactor(dates): migrate oeFormatDateTime to DateFormatterUtils and add tests — @kojiromike
+- [#10761](https://github.com/openemr/openemr/pull/10761) refactor(gacl): Narrow scope and apply correct type to Gacl properties — @Firehed
+- [#10982](https://github.com/openemr/openemr/pull/10982) refactor(crypto): Migrate CryptoGen to CryptoInterface — @Firehed
+- [#11252](https://github.com/openemr/openemr/pull/11252) refactor(api): replace $_GET with $request->query in REST routes — @kojiromike
+- [#11068](https://github.com/openemr/openemr/pull/11068) refactor(globals): use getInt() for numeric OEGlobalsBag settings — @kojiromike
+- [#11229](https://github.com/openemr/openemr/pull/11229) refactor(auth): replace raw SQL parameter in AuthUtils::updatePassword() — @kojiromike
+- [#11023](https://github.com/openemr/openemr/pull/11023) refactor(tests): add native PHP types to ApiTestClient and BulkAPITestClient — @kojiromike
+- [#11082](https://github.com/openemr/openemr/pull/11082) refactor(db): Move dbal connection into factory — @Firehed
+- [#11078](https://github.com/openemr/openemr/pull/11078) refactor(audit): Extract DB loggers from EventAuditLogger — @Firehed
+- [#11050](https://github.com/openemr/openemr/pull/11050) refactor(globals): use getBoolean() for boolean OEGlobalsBag settings — @kojiromike
+- [#10995](https://github.com/openemr/openemr/pull/10995) refactor(crypto): Pass enums instead of strings — @Firehed
+- [#11240](https://github.com/openemr/openemr/pull/11240) refactor(csrf): simplify collectCsrfToken() usage across codebase — @kojiromike
+- [#10967](https://github.com/openemr/openemr/pull/10967) refactor(phpstan): Add and correct missing type info — @Firehed
+- [#11244](https://github.com/openemr/openemr/pull/11244) refactor(acl): throw exceptions instead of exit() in controller ACL checks — @phantom930
+- [#10683](https://github.com/openemr/openemr/pull/10683) refactor(security): use AccessDeniedHelper for ACL denial patterns — @kojiromike
+- [#10688](https://github.com/openemr/openemr/pull/10688) refactor(health): use QueryUtils in DatabaseCheck — @Firehed
+- [#10981](https://github.com/openemr/openemr/pull/10981) refactor(crypto): Encapsulate legacy decryption methods — @Firehed
+- [#10972](https://github.com/openemr/openemr/pull/10972) refactor(db): Simplify config file reading — @Firehed
+- [#11017](https://github.com/openemr/openemr/pull/11017) refactor: replace $GLOBALS access with OEGlobalsBag across the codebase — @kojiromike
+- [#10889](https://github.com/openemr/openemr/pull/10889) refactor(db): change $_db property from public to protected — @Firehed
+- [#10948](https://github.com/openemr/openemr/pull/10948) refactor(faxsms): replace magic vendor IDs with ServiceType enum — @kojiromike
+- [#11266](https://github.com/openemr/openemr/pull/11266) refactor: remove redundant `global $GLOBALS` declarations — @kojiromike
+- [#11014](https://github.com/openemr/openemr/pull/11014) refactor: use OEGlobalsBag::getKernel() instead of ->get('kernel') — @kojiromike
+- [#10942](https://github.com/openemr/openemr/pull/10942) refactor(auth): replace die() with RuntimeException in generatePortal… — @Boykosoft
+- [#10729](https://github.com/openemr/openemr/pull/10729) refactor: Deduplicate more global functions — @Firehed
+- [#10884](https://github.com/openemr/openemr/pull/10884) refactor(db): migrate get_db() calls to QueryUtils — @Firehed
+- [#10840](https://github.com/openemr/openemr/pull/10840) refactor(format-money): use OEGlobalsBag and add isolated tests — @kojiromike
+- [#11131](https://github.com/openemr/openemr/pull/11131) refactor(crypto): Start to add DI support to CryptoGen — @Firehed
+- [#11113](https://github.com/openemr/openemr/pull/11113) refactor(audit): Get most global state out of the instance path — @Firehed
+- [#11108](https://github.com/openemr/openemr/pull/11108) refactor(logging): Remove most remaining coupling to SystemLogger — @Firehed
+- [#11088](https://github.com/openemr/openemr/pull/11088) refactor(log): Update many SystemLogger to Psr LoggerInterface — @Firehed
+- [#10803](https://github.com/openemr/openemr/pull/10803) refactor(db): centralize connection persistence detection — @Firehed
+- [#10790](https://github.com/openemr/openemr/pull/10790) refactor: Deduplicate more global functions — @Firehed
+- [#10779](https://github.com/openemr/openemr/pull/10779) refactor: Fix most duplicate class definitions — @Firehed
+- [#11102](https://github.com/openemr/openemr/pull/11102) refactor(audit): Have log table and ATNA implement common interface — @Firehed
+- [#11100](https://github.com/openemr/openemr/pull/11100) refactor(logging): Avoid errorLogCaller() where exception context available — @Firehed
+- [#10773](https://github.com/openemr/openemr/pull/10773) refactor(calendar): Update PostNuke internals to DBAL — @Firehed
+- [#11105](https://github.com/openemr/openemr/pull/11105) refactor(audit): Make audit destinations ("sinks") configurable — @Firehed
+- [#10692](https://github.com/openemr/openemr/pull/10692) refactor(types): Add type annotations to CCR — @Firehed
+- [#10690](https://github.com/openemr/openemr/pull/10690) refactor(globals): Switch from error_log to standard system logger, fix status codes — @Firehed
+- [#10920](https://github.com/openemr/openemr/pull/10920) refactor(db): Remove sqlconfig event — @Firehed
+- [#10770](https://github.com/openemr/openemr/pull/10770) refactor(claimrev): use PSR-18 HTTP client — @kojiromike
+- [#11262](https://github.com/openemr/openemr/pull/11262) refactor(modules): stop constructing throwaway Kernel instances — @Copilot
+- [#11077](https://github.com/openemr/openemr/pull/11077) refactor(calendar): extract inline JS from add_edit_event.php — @haoyu-haoyu
+- [#11257](https://github.com/openemr/openemr/pull/11257) refactor(globals): enable getInt() and getString() typed getters — @kojiromike
+- [#11025](https://github.com/openemr/openemr/pull/11025) refactor(tests): convert non-FHIR JSON fixtures to PHP files — @kojiromike
+- [#10966](https://github.com/openemr/openemr/pull/10966) refactor(db): Update backup script to central config reads; exclude phpstan info — @Firehed
+- [#10913](https://github.com/openemr/openemr/pull/10913) refactor(crypto): remove silent failure handling from RandomGenUtils — @Firehed
+- [#10850](https://github.com/openemr/openemr/pull/10850) refactor(billing): return booleans instead of string values in connectivity checks — @jbaiad
+- [#10713](https://github.com/openemr/openemr/pull/10713) refactor(cron): Avoid duplicate function definitions — @Firehed
+- [#11048](https://github.com/openemr/openemr/pull/11048) refactor: convert remaining $GLOBALS existence checks to OEGlobalsBag — @kojiromike
+- [#10805](https://github.com/openemr/openemr/pull/10805) refactor(installer): use centralized database connection factory — @Firehed
+- [#9980](https://github.com/openemr/openemr/pull/9980) refactor(db): Doctrine/DBAL initial integration — @Firehed
+- [#10689](https://github.com/openemr/openemr/pull/10689) refactor(ccr): remove dead code and fix undefined variables — @Firehed
+- [#10691](https://github.com/openemr/openemr/pull/10691) refactor(modules): Fix a few missing/incorrect types — @Firehed
+- [#10596](https://github.com/openemr/openemr/pull/10596) refactor(db): Remove getSqlLastError() global function, improve types — @Firehed
+- [#10520](https://github.com/openemr/openemr/pull/10520) refactor(db): Move more logic from sql.inc to QueryUtils — @Firehed
+- [#10573](https://github.com/openemr/openemr/pull/10573) refactor(sql): remove QuotedOrNull and convert to prepared statements — @Firehed
+
+## Chores
+
+- [#12794](https://github.com/openemr/openemr/pull/12794) chore(deps): bump nikic/php-parser from 5.7.0 to 5.8.0 — @dependabot[bot]
+- [#12793](https://github.com/openemr/openemr/pull/12793) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.33 to 9.0.34 — @dependabot[bot]
+- [#12801](https://github.com/openemr/openemr/pull/12801) chore(deps): bump guzzlehttp/guzzle from 7.12.3 to 7.13.2 — @dependabot[bot]
+- [#12800](https://github.com/openemr/openemr/pull/12800) chore(deps-dev): bump psy/psysh from 0.12.23 to 0.12.24 — @dependabot[bot]
+- [#12797](https://github.com/openemr/openemr/pull/12797) chore(deps-dev): bump webpack from 5.108.1 to 5.108.4 in the build-tools group — @dependabot[bot]
+- [#12796](https://github.com/openemr/openemr/pull/12796) chore(deps): bump smarty/smarty from 4.5.6 to 4.5.7 — @dependabot[bot]
+- [#12799](https://github.com/openemr/openemr/pull/12799) chore(deps): bump twig/twig from 3.27.1 to 3.28.0 — @dependabot[bot]
+- [#12802](https://github.com/openemr/openemr/pull/12802) chore(deps): bump google/apiclient from 2.19.3 to 2.19.4 — @dependabot[bot]
+- [#12764](https://github.com/openemr/openemr/pull/12764) chore(phpstan): Fix weird variant type in legacy phreeze path — @Firehed
+- [#12706](https://github.com/openemr/openemr/pull/12706) chore(coderabbit): skip auto-review on bot-authored PRs — @bradymiller
+- [#12676](https://github.com/openemr/openemr/pull/12676) chore(deps-dev): bump globals from 17.6.0 to 17.7.0 in /ccdaservice — @dependabot[bot]
+- [#12687](https://github.com/openemr/openemr/pull/12687) chore(deps): bump league/flysystem from 3.34.0 to 3.35.1 — @dependabot[bot]
+- [#12685](https://github.com/openemr/openemr/pull/12685) chore(deps): bump claimrevolution/oe-module-claimrev-connect from 2.1.5 to 2.1.6 — @dependabot[bot]
+- [#12680](https://github.com/openemr/openemr/pull/12680) chore(deps-dev): bump postcss from 8.5.15 to 8.5.16 — @dependabot[bot]
+- [#12543](https://github.com/openemr/openemr/pull/12543) chore(deps): bump guzzlehttp/psr7 from 2.11.0 to 2.12.1 in /interface/modules/custom_modules/oe-module-faxsms — @dependabot[bot]
+- [#12686](https://github.com/openemr/openemr/pull/12686) chore(deps): bump guzzlehttp/guzzle from 7.12.1 to 7.12.3 — @dependabot[bot]
+- [#12684](https://github.com/openemr/openemr/pull/12684) chore(deps): bump guzzlehttp/psr7 from 2.12.1 to 2.12.3 — @dependabot[bot]
+- [#12683](https://github.com/openemr/openemr/pull/12683) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.32 to 9.0.33 — @dependabot[bot]
+- [#12682](https://github.com/openemr/openemr/pull/12682) chore(deps-dev): bump slevomat/coding-standard from 8.29.0 to 8.30.1 — @dependabot[bot]
+- [#12679](https://github.com/openemr/openemr/pull/12679) chore(deps): bump the symfony group with 11 updates — @dependabot[bot]
+- [#12677](https://github.com/openemr/openemr/pull/12677) chore(deps-dev): bump autoprefixer from 10.5.0 to 10.5.2 — @dependabot[bot]
+- [#12675](https://github.com/openemr/openemr/pull/12675) chore(deps-dev): bump webpack from 5.107.2 to 5.108.1 in the build-tools group — @dependabot[bot]
+- [#12654](https://github.com/openemr/openemr/pull/12654) chore(di): Prepare BreakglassChecker(Interface) for autowiring — @Firehed
+- [#12614](https://github.com/openemr/openemr/pull/12614) chore: gitignore .worktrees.json.lock/ directory — @bradymiller
+- [#12545](https://github.com/openemr/openemr/pull/12545) chore(deps): bump guzzlehttp/guzzle from 7.11.1 to 7.12.1 in /interface/modules/custom_modules/oe-module-faxsms — @dependabot[bot]
+- [#12600](https://github.com/openemr/openemr/pull/12600) chore(deps): bump uuid from 14.0.0 to 14.0.1 in /ccdaservice — @dependabot[bot]
+- [#12601](https://github.com/openemr/openemr/pull/12601) chore(phpstan): refresh RESERVED_WORD_SUPPLEMENT — @openemr-reserved-word-bot[bot]
+- [#12556](https://github.com/openemr/openemr/pull/12556) chore(deps): bump claimrevolution/oe-module-claimrev-connect from 2.1.4 to 2.1.5 — @dependabot[bot]
+- [#12554](https://github.com/openemr/openemr/pull/12554) chore(deps-dev): bump justinrainbow/json-schema from 6.9.0 to 6.10.0 — @dependabot[bot]
+- [#12555](https://github.com/openemr/openemr/pull/12555) chore(deps): bump ramsey/uuid from 4.9.2 to 4.9.3 — @dependabot[bot]
+- [#12561](https://github.com/openemr/openemr/pull/12561) chore(deps): bump https://github.com/macisamuele/language-formatters-pre-commit-hooks from v2.14.0 to 2.16.0 — @dependabot[bot]
+- [#12560](https://github.com/openemr/openemr/pull/12560) chore(deps): bump https://github.com/codespell-project/codespell from v2.4.1 to 2.4.2 — @dependabot[bot]
+- [#12557](https://github.com/openemr/openemr/pull/12557) chore(deps): bump https://github.com/pre-commit/pre-commit-hooks from v4.5.0 to 6.0.0 — @dependabot[bot]
+- [#12566](https://github.com/openemr/openemr/pull/12566) chore(composer): ext-posix in `require-dev` breaks `composer install` on Windows — @sjpadgett
+- [#12552](https://github.com/openemr/openemr/pull/12552) chore(pre-commit): wire hadolint into local hooks — @bradymiller
+- [#12544](https://github.com/openemr/openemr/pull/12544) chore(deps): bump guzzlehttp/guzzle from 7.11.1 to 7.12.1 — @dependabot[bot]
+- [#12542](https://github.com/openemr/openemr/pull/12542) chore(deps): bump guzzlehttp/psr7 from 2.11.0 to 2.12.1 — @dependabot[bot]
+- [#12499](https://github.com/openemr/openemr/pull/12499) chore(deps): bump phpseclib/phpseclib from 3.0.53 to 3.0.55 — @dependabot[bot]
+- [#12533](https://github.com/openemr/openemr/pull/12533) chore(deps): bump dompurify from 3.4.10 to 3.4.11 — @dependabot[bot]
+- [#12532](https://github.com/openemr/openemr/pull/12532) chore(cli): Exit with a nonzero code if bootstrap fails — @Firehed
+- [#12531](https://github.com/openemr/openemr/pull/12531) chore(ci): Instruct CodeRabbit to not edit the main PR body — @Firehed
+- [#12505](https://github.com/openemr/openemr/pull/12505) chore(deps): bump js-yaml from 4.1.1 to 4.2.0 in /ccdaservice — @dependabot[bot]
+- [#12504](https://github.com/openemr/openemr/pull/12504) chore(deps): bump tar from 7.5.11 to 7.5.16 in /ccdaservice — @dependabot[bot]
+- [#12502](https://github.com/openemr/openemr/pull/12502) chore(deps): bump dompurify from 3.4.9 to 3.4.10 — @dependabot[bot]
+- [#12498](https://github.com/openemr/openemr/pull/12498) chore(deps): bump zircote/swagger-php from 6.1.2 to 6.2.0 — @dependabot[bot]
+- [#12523](https://github.com/openemr/openemr/pull/12523) chore: phpstan fixes and other unrelated fixes — @bradymiller
+- [#12522](https://github.com/openemr/openemr/pull/12522) chore(dbal): Groundwork for connecting to ORM and migration events — @Firehed
+- [#12501](https://github.com/openemr/openemr/pull/12501) chore(deps-dev): bump sass from 1.100.0 to 1.101.0 — @dependabot[bot]
+- [#12500](https://github.com/openemr/openemr/pull/12500) chore(deps-dev): bump eslint from 10.4.1 to 10.5.0 in /ccdaservice — @dependabot[bot]
+- [#12468](https://github.com/openemr/openemr/pull/12468) chore(deps): drop unused laminas-xmlrpc and confirm 8.5 resolution path — @kojiromike
+- [#12467](https://github.com/openemr/openemr/pull/12467) chore(deps): bump guzzlehttp/psr7 from 2.7.0 to 2.11.0 in /interface/modules/custom_modules/oe-module-faxsms — @dependabot[bot]
+- [#12466](https://github.com/openemr/openemr/pull/12466) chore(docker): wall off webpack cache in dev-easy compose envs — @bradymiller
+- [#12465](https://github.com/openemr/openemr/pull/12465) chore(deps): pin express version range in ccdaservice lockfile — @bradymiller
+- [#12451](https://github.com/openemr/openemr/pull/12451) chore(deps): bump dompurify from 3.4.8 to 3.4.9 — @dependabot[bot]
+- [#12448](https://github.com/openemr/openemr/pull/12448) chore(deps): bump phpseclib/phpseclib from 3.0.52 to 3.0.53 — @dependabot[bot]
+- [#12450](https://github.com/openemr/openemr/pull/12450) chore(deps-dev): bump sass from 1.86.0 to 1.100.0 — @dependabot[bot]
+- [#12447](https://github.com/openemr/openemr/pull/12447) chore(deps-dev): bump webpack from 5.105.4 to 5.107.2 in the build-tools group — @dependabot[bot]
+- [#12449](https://github.com/openemr/openemr/pull/12449) chore(deps): bump firehed/container from 1.0.0 to 1.1.0 — @dependabot[bot]
+- [#12452](https://github.com/openemr/openemr/pull/12452) chore(deps-dev): bump mini-css-extract-plugin from 2.10.1 to 2.10.2 — @dependabot[bot]
+- [#12416](https://github.com/openemr/openemr/pull/12416) chore(deps): bump phpoffice/phpspreadsheet from 5.7.0 to 5.8.0 — @dependabot[bot]
+- [#12413](https://github.com/openemr/openemr/pull/12413) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.31 to 9.0.32 — @dependabot[bot]
+- [#12412](https://github.com/openemr/openemr/pull/12412) chore(deps-dev): bump justinrainbow/json-schema from 6.8.2 to 6.9.0 — @dependabot[bot]
+- [#12415](https://github.com/openemr/openemr/pull/12415) chore(deps): bump claimrevolution/oe-module-claimrev-connect from 2.1.3 to 2.1.4 — @dependabot[bot]
+- [#12363](https://github.com/openemr/openemr/pull/12363) chore(deps): bump twig/twig from 3.26.0 to 3.27.1 — @dependabot[bot]
+- [#12411](https://github.com/openemr/openemr/pull/12411) chore(deps): bump guzzlehttp/guzzle from 7.10.6 to 7.11.1 — @dependabot[bot]
+- [#12414](https://github.com/openemr/openemr/pull/12414) chore(deps): bump guzzlehttp/psr7 from 2.10.4 to 2.11.0 — @dependabot[bot]
+- [#12417](https://github.com/openemr/openemr/pull/12417) chore(deps): bump digitickets/lalit from 3.4.1 to 3.4.2 — @dependabot[bot]
+- [#12418](https://github.com/openemr/openemr/pull/12418) chore(deps): bump dompurify from 3.4.7 to 3.4.8 — @dependabot[bot]
+- [#12405](https://github.com/openemr/openemr/pull/12405) chore: remove unused Laminas\Mvc import in FHIRSearchFieldFactory — @kojiromike
+- [#12355](https://github.com/openemr/openemr/pull/12355) chore(deps): bump select2 from 4.0.13 to 4.1.0 in the ui-components group — @dependabot[bot]
+- [#12356](https://github.com/openemr/openemr/pull/12356) chore(deps): bump the symfony group with 8 updates — @dependabot[bot]
+- [#12360](https://github.com/openemr/openemr/pull/12360) chore(deps): bump guzzlehttp/guzzle from 7.10.4 to 7.10.6 — @dependabot[bot]
+- [#12383](https://github.com/openemr/openemr/pull/12383) chore(actions): pin runner to ubuntu-24.04 — @kojiromike
+- [#12362](https://github.com/openemr/openemr/pull/12362) chore(deps): bump guzzlehttp/psr7 from 2.10.1 to 2.10.4 — @dependabot[bot]
+- [#12361](https://github.com/openemr/openemr/pull/12361) chore(deps): bump dompurify from 3.4.5 to 3.4.7 — @dependabot[bot]
+- [#12359](https://github.com/openemr/openemr/pull/12359) chore(deps): bump doctrine/orm from 3.6.6 to 3.6.7 — @dependabot[bot]
+- [#12364](https://github.com/openemr/openemr/pull/12364) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.30 to 9.0.31 — @dependabot[bot]
+- [#12381](https://github.com/openemr/openemr/pull/12381) chore(deps): add ext-redis to composer config.platform — @bradymiller
+- [#12373](https://github.com/openemr/openemr/pull/12373) chore(phpstan): refresh RESERVED_WORD_SUPPLEMENT — @openemr-reserved-word-bot[bot]
+- [#12292](https://github.com/openemr/openemr/pull/12292) chore(deps-dev): bump symfony/dom-crawler from 7.4.8 to 7.4.12 — @dependabot[bot]
+- [#12111](https://github.com/openemr/openemr/pull/12111) chore(deps): bump twilio/sdk from 8.11.5 to 8.11.6 — @dependabot[bot]
+- [#12227](https://github.com/openemr/openemr/pull/12227) chore(deps): bump twig/twig from 3.25.0 to 3.26.0 — @dependabot[bot]
+- [#12270](https://github.com/openemr/openemr/pull/12270) chore(deps): bump the symfony group across 1 directory with 4 updates — @dependabot[bot]
+- [#12156](https://github.com/openemr/openemr/pull/12156) chore(deps-dev): bump the development group across 1 directory with 2 updates — @dependabot[bot]
+- [#12112](https://github.com/openemr/openemr/pull/12112) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.29 to 9.0.30 — @dependabot[bot]
+- [#12113](https://github.com/openemr/openemr/pull/12113) chore(deps-dev): bump slevomat/coding-standard from 8.28.1 to 8.29.0 — @dependabot[bot]
+- [#12157](https://github.com/openemr/openemr/pull/12157) chore(deps): bump league/flysystem from 3.33.0 to 3.34.0 — @dependabot[bot]
+- [#12158](https://github.com/openemr/openemr/pull/12158) chore(deps-dev): bump ergebnis/composer-normalize from 2.51.0 to 2.52.0 — @dependabot[bot]
+- [#12160](https://github.com/openemr/openemr/pull/12160) chore(deps): bump twig/twig from 3.24.0 to 3.25.0 — @dependabot[bot]
+- [#12161](https://github.com/openemr/openemr/pull/12161) chore(deps): bump knplabs/knp-snappy from 1.6.0 to 1.7.2 — @dependabot[bot]
+- [#12162](https://github.com/openemr/openemr/pull/12162) chore(deps): bump express from 4.22.1 to 4.22.2 in /ccdaservice — @dependabot[bot]
+- [#12169](https://github.com/openemr/openemr/pull/12169) chore(deps): bump setasign/fpdi from 2.6.6 to 2.6.7 — @dependabot[bot]
+- [#12234](https://github.com/openemr/openemr/pull/12234) chore(deps): bump guzzlehttp/psr7 from 2.9.0 to 2.10.1 — @dependabot[bot]
+- [#12237](https://github.com/openemr/openemr/pull/12237) chore(deps): bump doctrine/orm from 3.6.5 to 3.6.6 — @dependabot[bot]
+- [#12240](https://github.com/openemr/openemr/pull/12240) chore(deps-dev): bump mocha from 11.7.5 to 11.7.6 in /ccdaservice — @dependabot[bot]
+- [#12241](https://github.com/openemr/openemr/pull/12241) chore(deps-dev): bump postcss from 8.5.14 to 8.5.15 — @dependabot[bot]
+- [#12264](https://github.com/openemr/openemr/pull/12264) chore(deps): bump guzzlehttp/guzzle from 7.10.0 to 7.10.4 — @dependabot[bot]
+- [#12245](https://github.com/openemr/openemr/pull/12245) chore: clear arrayValues.list + smaller.invalid PHPStan baseline entries — @bradymiller
+- [#12159](https://github.com/openemr/openemr/pull/12159) chore(deps): bump dompurify from 3.4.2 to 3.4.5 — @dependabot[bot]
+- [#12164](https://github.com/openemr/openemr/pull/12164) chore(deps): bump @tootallnate/once and jest-environment-jsdom — @dependabot[bot]
+- [#12145](https://github.com/openemr/openemr/pull/12145) chore: clean up js_escape() patterns — @Kasirocswell
+- [#12114](https://github.com/openemr/openemr/pull/12114) chore(deps): bump doctrine/orm from 3.6.3 to 3.6.5 — @dependabot[bot]
+- [#12095](https://github.com/openemr/openemr/pull/12095) chore(deps-dev): bump fast-uri from 3.1.0 to 3.1.2 in /interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js — @dependabot[bot]
+- [#12092](https://github.com/openemr/openemr/pull/12092) chore(deps): bump fast-uri from 3.0.6 to 3.1.2 — @dependabot[bot]
+- [#12045](https://github.com/openemr/openemr/pull/12045) chore(deps-dev): bump postcss from 8.5.13 to 8.5.14 — @dependabot[bot]
+- [#12044](https://github.com/openemr/openemr/pull/12044) chore(deps): bump google/apiclient from 2.19.2 to 2.19.3 — @dependabot[bot]
+- [#12043](https://github.com/openemr/openemr/pull/12043) chore(deps): bump twilio/sdk from 8.11.4 to 8.11.5 — @dependabot[bot]
+- [#12042](https://github.com/openemr/openemr/pull/12042) chore(deps): bump moneyphp/money from 4.8.0 to 4.9.0 — @dependabot[bot]
+- [#12041](https://github.com/openemr/openemr/pull/12041) chore(deps): bump the symfony group with 6 updates — @dependabot[bot]
+- [#12038](https://github.com/openemr/openemr/pull/12038) chore(deps): bump mongoose from 7.8.8 to 7.8.9 in /ccdaservice — @dependabot[bot]
+- [#12037](https://github.com/openemr/openemr/pull/12037) chore(deps): bump ip-address from 10.1.0 to 10.2.0 in /ccdaservice — @dependabot[bot]
+- [#11569](https://github.com/openemr/openemr/pull/11569) chore: standardize OpenCoreEMR copyright headers — @kojiromike
+- [#11637](https://github.com/openemr/openemr/pull/11637) chore(testing): move database-independent tests to isolated suite — @kojiromike
+- [#11653](https://github.com/openemr/openemr/pull/11653) chore(db): Baseline tooling for doctrine/migrations conversion — @Firehed
+- [#11679](https://github.com/openemr/openemr/pull/11679) chore(modules): remove abandoned sms_email_reminder — @kojiromike
+- [#11703](https://github.com/openemr/openemr/pull/11703) chore(api): Update swagger schema — @Firehed
+- [#11744](https://github.com/openemr/openemr/pull/11744) chore(ci): exclude config/ from test coverage — @Firehed
+- [#11771](https://github.com/openemr/openemr/pull/11771) chore(db): Pre-create Doctrine migrations table — @Firehed
+- [#11773](https://github.com/openemr/openemr/pull/11773) chore(db): Remove forward upgrade from release — @Firehed
+- [#11820](https://github.com/openemr/openemr/pull/11820) chore(phpstan): drain return.missing baseline (29 → 0) — @kojiromike
+- [#11821](https://github.com/openemr/openemr/pull/11821) chore(phpstan): drain confident nonObject baselines (21 → 0) — @kojiromike
+- [#11823](https://github.com/openemr/openemr/pull/11823) chore(phpstan): drain constant.notFound baseline (123 → 0) — @kojiromike
+- [#11825](https://github.com/openemr/openemr/pull/11825) chore(phpstan): drain eRx method.notFound entries (253 → 189) — @kojiromike
+- [#11826](https://github.com/openemr/openemr/pull/11826) chore(phpstan): drain variable.undefined in gacl/admin (3446 → 3399) — @kojiromike
+- [#11859](https://github.com/openemr/openemr/pull/11859) chore(phpstan): drain Carecoordination module class.notFound + method.notFound — @kojiromike
+- [#11867](https://github.com/openemr/openemr/pull/11867) chore(db): Fix typo — @Firehed
+- [#11878](https://github.com/openemr/openemr/pull/11878) chore(phpstan): drain edihistory baseline (method.notFound, variable.undefined) — @kojiromike
+- [#11887](https://github.com/openemr/openemr/pull/11887) chore(phpstan): drain variable.undefined baseline (3064 → 2927) — @kojiromike
+- [#11901](https://github.com/openemr/openemr/pull/11901) chore(phpstan): drain variable.undefined baseline in interface/main — @kojiromike
+- [#11902](https://github.com/openemr/openemr/pull/11902) chore(phpstan): drain variable.undefined across interface/patient_file — @kojiromike
+- [#11903](https://github.com/openemr/openemr/pull/11903) chore(phpstan): drain variable.undefined baseline for edihistory, modules, reports, services — @kojiromike
+- [#11914](https://github.com/openemr/openemr/pull/11914) chore(phpstan): cap phpDoc.parseError baseline at zero — @kojiromike
+- [#11920](https://github.com/openemr/openemr/pull/11920) chore(phpstan): drain variable.undefined baseline for interface/forms/eye_mag (1835 → 800) — @kojiromike
+- [#11954](https://github.com/openemr/openemr/pull/11954) chore(phpstan): drain variable.undefined for canonical-globals form files (800 → 708) — @kojiromike
+- [#11963](https://github.com/openemr/openemr/pull/11963) chore(phpstan): drain variable.undefined for interface/forms (708 → 586) — @kojiromike
+- [#11996](https://github.com/openemr/openemr/pull/11996) chore(phpstan): regenerate baseline for phpstan 2.1.54 — @kojiromike
+- [#12001](https://github.com/openemr/openemr/pull/12001) chore(phpstan): Clean up some issues in Document — @Firehed
+- [#11993](https://github.com/openemr/openemr/pull/11993) chore(deps): bump zircote/swagger-php from 6.1.1 to 6.1.2 — @dependabot[bot]
+- [#11991](https://github.com/openemr/openemr/pull/11991) chore(deps-dev): bump the development group with 2 updates — @dependabot[bot]
+- [#11990](https://github.com/openemr/openemr/pull/11990) chore(deps): bump the symfony group with 7 updates — @dependabot[bot]
+- [#11994](https://github.com/openemr/openemr/pull/11994) chore(deps-dev): bump postcss from 8.5.12 to 8.5.13 — @dependabot[bot]
+- [#11992](https://github.com/openemr/openemr/pull/11992) chore(deps): bump dompurify from 3.4.1 to 3.4.2 — @dependabot[bot]
+- [#11844](https://github.com/openemr/openemr/pull/11844) chore(deps): bump body-parser from 1.20.4 to 1.20.5 in /ccdaservice — @dependabot[bot]
+- [#11780](https://github.com/openemr/openemr/pull/11780) chore(deps): bump uuid from 11.1.0 to 14.0.0 in /ccdaservice — @dependabot[bot]
+- [#11722](https://github.com/openemr/openemr/pull/11722) chore(deps-dev): bump grunt from 1.6.1 to 1.6.2 in /ccdaservice — @dependabot[bot]
+- [#11838](https://github.com/openemr/openemr/pull/11838) chore(deps-dev): bump phpstan/phpstan from 2.1.50 to 2.1.51 in the development group across 1 directory — @dependabot[bot]
+- [#11841](https://github.com/openemr/openemr/pull/11841) chore(deps): bump phpseclib/phpseclib from 3.0.51 to 3.0.52 — @dependabot[bot]
+- [#11842](https://github.com/openemr/openemr/pull/11842) chore(deps): bump dompurify from 3.4.0 to 3.4.1 — @dependabot[bot]
+- [#11843](https://github.com/openemr/openemr/pull/11843) chore(deps-dev): bump postcss from 8.5.10 to 8.5.12 — @dependabot[bot]
+- [#11839](https://github.com/openemr/openemr/pull/11839) chore(deps): bump doctrine/migrations from 3.9.6 to 3.9.7 — @dependabot[bot]
+- [#11840](https://github.com/openemr/openemr/pull/11840) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.28 to 9.0.29 — @dependabot[bot]
+- [#11775](https://github.com/openemr/openemr/pull/11775) chore(deps): bump @xmldom/xmldom from 0.9.9 to 0.9.10 in /ccdaservice/packages/oe-cda-schematron — @dependabot[bot]
+- [#11713](https://github.com/openemr/openemr/pull/11713) chore(deps-dev): bump the development group across 1 directory with 2 updates — @dependabot[bot]
+- [#11718](https://github.com/openemr/openemr/pull/11718) chore(deps): bump zircote/swagger-php from 6.1.0 to 6.1.1 — @dependabot[bot]
+- [#11720](https://github.com/openemr/openemr/pull/11720) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.27 to 9.0.28 — @dependabot[bot]
+- [#11719](https://github.com/openemr/openemr/pull/11719) chore(deps-dev): bump postcss from 8.5.9 to 8.5.10 — @dependabot[bot]
+- [#11717](https://github.com/openemr/openemr/pull/11717) chore(deps-dev): bump autoprefixer from 10.4.27 to 10.5.0 — @dependabot[bot]
+- [#11716](https://github.com/openemr/openemr/pull/11716) chore(deps): bump twilio/sdk from 8.11.3 to 8.11.4 — @dependabot[bot]
+- [#11714](https://github.com/openemr/openemr/pull/11714) chore(deps): bump phpoffice/phpspreadsheet from 5.6.0 to 5.7.0 — @dependabot[bot]
+- [#11715](https://github.com/openemr/openemr/pull/11715) chore(deps-dev): bump ergebnis/composer-normalize from 2.50.0 to 2.51.0 — @dependabot[bot]
+- [#11654](https://github.com/openemr/openemr/pull/11654) chore(deps): bump dompurify from 3.3.3 to 3.4.0 — @dependabot[bot]
+- [#10929](https://github.com/openemr/openemr/pull/10929) chore(globals): remove 19 unused global definitions — @Copilot
+- [#10816](https://github.com/openemr/openemr/pull/10816) chore(phpstan): Add/fix common type hints — @Firehed
+- [#11180](https://github.com/openemr/openemr/pull/11180) chore(docs): add missing GHSA and fix advisory URLs in 8.0.0.2 changelog — @kojiromike
+- [#11176](https://github.com/openemr/openemr/pull/11176) chore(docs): Update changelog for 8.0.0.2 — @Firehed
+- [#11301](https://github.com/openemr/openemr/pull/11301) chore(docs): update AI guidelines files for commit trailers — @Copilot
+- [#11412](https://github.com/openemr/openemr/pull/11412) chore(globals): Move function definitions out of globals.php — @Firehed
+- [#11406](https://github.com/openemr/openemr/pull/11406) chore(cleanup): Sort functions in autoloaded function file — @Firehed
+- [#11445](https://github.com/openemr/openemr/pull/11445) chore(encryption): Move KeyId primitive up to top namespace — @Firehed
+- [#11447](https://github.com/openemr/openemr/pull/11447) chore(encryption): Adjust wrapped values in primitives — @Firehed
+- [#11501](https://github.com/openemr/openemr/pull/11501) chore(errors): Improve handling for Symfony HTTP errors — @Firehed
+- [#11517](https://github.com/openemr/openemr/pull/11517) chore(deps): upgrade Symfony components to 7.x — @Firehed
+- [#10900](https://github.com/openemr/openemr/pull/10900) chore(ci): raise codecov coverage targets (#10571) — @craigrallen
+- [#11495](https://github.com/openemr/openemr/pull/11495) chore: support for alpine 3.23 with php 8.5 and nodejs 24 — @bradymiller
+- [#11508](https://github.com/openemr/openemr/pull/11508) chore: rel-810 support for worktrees and alpine 3.23 — @bradymiller
+- [#11299](https://github.com/openemr/openemr/pull/11299) chore(camos): remove mitigateSqlTableUpperCase() wrapper — @Copilot
+- [#11376](https://github.com/openemr/openemr/pull/11376) chore(database): rename Audit connection to NonAudited — @Firehed
+- [#11306](https://github.com/openemr/openemr/pull/11306) chore(ci): Remove PHPUnit `--testdox` format from CI — @Copilot
+- [#11373](https://github.com/openemr/openemr/pull/11373) chore(crypto): replace mb_substr/mb_strlen with substr/strlen in binary operations — @haoyu-haoyu
+- [#11411](https://github.com/openemr/openemr/pull/11411) chore(logging): Add and initialize basic fallback exception handler — @Firehed
+- [#11341](https://github.com/openemr/openemr/pull/11341) chore(docker): prep for rel-810 — @stephenwaite
+- [#11417](https://github.com/openemr/openemr/pull/11417) chore(utilities): Refactor and add tests for fixDate — @Firehed
+- [#11514](https://github.com/openemr/openemr/pull/11514) chore: drop unnecessary fgets() length limits — @haoyu-haoyu
+- [#11534](https://github.com/openemr/openemr/pull/11534) chore(ci): bump mariadb to 12.2 — @stephenwaite
+- [#11523](https://github.com/openemr/openemr/pull/11523) chore(deps-dev): bump rector/rector from 2.4.0 to 2.4.1 in the development group across 1 directory — @dependabot[bot]
+- [#11526](https://github.com/openemr/openemr/pull/11526) chore(deps): bump zircote/swagger-php from 6.0.6 to 6.1.0 — @dependabot[bot]
+- [#11529](https://github.com/openemr/openemr/pull/11529) chore(deps): bump phpseclib/phpseclib from 3.0.50 to 3.0.51 — @dependabot[bot]
+- [#11530](https://github.com/openemr/openemr/pull/11530) chore(deps): bump ckeditor5 from 47.6.1 to 47.6.2 — @dependabot[bot]
+- [#11531](https://github.com/openemr/openemr/pull/11531) chore(deps-dev): bump postcss from 8.5.8 to 8.5.9 — @dependabot[bot]
+- [#11527](https://github.com/openemr/openemr/pull/11527) chore(deps): bump phpoffice/phpspreadsheet from 5.5.0 to 5.6.0 — @dependabot[bot]
+- [#11181](https://github.com/openemr/openemr/pull/11181) chore(testing): show PHPUnit deprecation details in test output — @Daedalus-Icarus
+- [#11133](https://github.com/openemr/openemr/pull/11133) chore(deps): drop direct laminas/laminas-json requirement — @kojiromike
+- [#11295](https://github.com/openemr/openemr/pull/11295) chore(version): set version to 8.1.0 for release branch — @kojiromike
+- [#11311](https://github.com/openemr/openemr/pull/11311) chore: change upgrade script to 8.1.0 — @bradymiller
+- [#10766](https://github.com/openemr/openemr/pull/10766) chore: bump v_database — @stephenwaite
+- [#11083](https://github.com/openemr/openemr/pull/11083) chore: remove 2015 reference — @stephenwaite
+- [#11081](https://github.com/openemr/openemr/pull/11081) chore: changelog 8.0.0.1 — @bradymiller
+- [#11213](https://github.com/openemr/openemr/pull/11213) chore: add export-ignore rules to .gitattributes — @kojiromike
+- [#11289](https://github.com/openemr/openemr/pull/11289) chore(encryption): Add and integrate ciphertext wrapper — @Firehed
+- [#11283](https://github.com/openemr/openemr/pull/11283) chore(docs): Adjust changelog so it doesn't trigger spellcheck errors on all PRs — @Firehed
+- [#11292](https://github.com/openemr/openemr/pull/11292) chore(ci): Run PHPStan on 8.5 — @Firehed
+- [#11276](https://github.com/openemr/openemr/pull/11276) chore(docs): add 8.0.0.3 changelog — @kojiromike
+- [#11247](https://github.com/openemr/openemr/pull/11247) chore(crypto): Modularize cryptographic ciphers — @Firehed
+- [#10932](https://github.com/openemr/openemr/pull/10932) chore(deps): bump minimatch to fix ReDoS (CVE-2026-26996) — @kojiromike
+- [#11033](https://github.com/openemr/openemr/pull/11033) chore(deps): bump immutable 4.3.7 → 4.3.8 in ccdaservice — @kojiromike
+- [#10994](https://github.com/openemr/openemr/pull/10994) chore(phpcs): Group and sort `use` statements — @Firehed
+- [#10639](https://github.com/openemr/openemr/pull/10639) chore(portal): remove dead verysimple DB drivers — @kojiromike
+- [#10938](https://github.com/openemr/openemr/pull/10938) chore(ci): Add unused use statement linting — @Firehed
+- [#10927](https://github.com/openemr/openemr/pull/10927) chore(db): Remove multipledb module — @Firehed
+- [#10916](https://github.com/openemr/openemr/pull/10916) chore(phpstan): Tell composer phpstan to prefer dist config — @Firehed
+- [#10801](https://github.com/openemr/openemr/pull/10801) chore(db): Remove charset option — @Firehed
+- [#11107](https://github.com/openemr/openemr/pull/11107) chore(testing): Default to NullLogger  in tests — @Firehed
+- [#11432](https://github.com/openemr/openemr/pull/11432) chore(deps-dev): bump the development group with 2 updates — @dependabot[bot]
+- [#11230](https://github.com/openemr/openemr/pull/11230) chore(testing): migrate @dataProvider annotations to PHP 8 attributes — @haoyu-haoyu
+- [#11159](https://github.com/openemr/openemr/pull/11159) chore(testing): Improve code coverage reporting for isolated tests — @Daedalus-Icarus
+- [#11204](https://github.com/openemr/openemr/pull/11204) chore(deps): resolve composer dependency blockers for PHP 8.4 — @kojiromike
+- [#10965](https://github.com/openemr/openemr/pull/10965) chore(db): Remove laminas-db package dependency — @Firehed
+- [#10921](https://github.com/openemr/openemr/pull/10921) chore(api): Upgrade swagger-php to 6.x with PHP 8 attributes — @Firehed
+- [#10789](https://github.com/openemr/openemr/pull/10789) chore(db): Remove legacy non-utf8 connection support — @Firehed
+- [#11435](https://github.com/openemr/openemr/pull/11435) chore(deps): bump bacon/bacon-qr-code from 3.0.4 to 3.1.1 — @dependabot[bot]
+- [#11436](https://github.com/openemr/openemr/pull/11436) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.26 to 9.0.27 — @dependabot[bot]
+- [#11434](https://github.com/openemr/openemr/pull/11434) chore(deps): bump google/apiclient from 2.19.1 to 2.19.2 — @dependabot[bot]
+- [#11433](https://github.com/openemr/openemr/pull/11433) chore(deps): bump digitickets/lalit from 3.4.0 to 3.4.1 — @dependabot[bot]
+- [#11431](https://github.com/openemr/openemr/pull/11431) chore(deps): bump the symfony group with 5 updates — @dependabot[bot]
+- [#11415](https://github.com/openemr/openemr/pull/11415) chore(deps): bump lodash from 4.17.23 to 4.18.1 in /ccdaservice — @dependabot[bot]
+- [#11356](https://github.com/openemr/openemr/pull/11356) chore(deps): bump @xmldom/xmldom from 0.9.8 to 0.9.9 in /ccdaservice — @dependabot[bot]
+- [#11355](https://github.com/openemr/openemr/pull/11355) chore(deps): bump knockout from 3.5.2 to 3.5.3 — @dependabot[bot]
+- [#11354](https://github.com/openemr/openemr/pull/11354) chore(deps): bump twilio/sdk from 8.11.2 to 8.11.3 — @dependabot[bot]
+- [#11353](https://github.com/openemr/openemr/pull/11353) chore(deps): bump google/apiclient from 2.19.0 to 2.19.1 — @dependabot[bot]
+- [#11352](https://github.com/openemr/openemr/pull/11352) chore(deps-dev): bump phpstan/phpstan from 2.1.42 to 2.1.44 in the development group — @dependabot[bot]
+- [#11324](https://github.com/openemr/openemr/pull/11324) chore(deps): bump path-to-regexp from 0.1.12 to 0.1.13 in /ccdaservice — @dependabot[bot]
+- [#11323](https://github.com/openemr/openemr/pull/11323) chore(deps): bump serialize-javascript and terser-webpack-plugin in /interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js — @dependabot[bot]
+- [#11322](https://github.com/openemr/openemr/pull/11322) chore(deps): bump brace-expansion from 2.0.2 to 2.0.3 in /ccdaservice — @dependabot[bot]
+- [#11310](https://github.com/openemr/openemr/pull/11310) chore: prep for 8.1.0 and 8.1.1 — @bradymiller
+- [#11296](https://github.com/openemr/openemr/pull/11296) chore(version): bump master dev version to 8.1.1 — @kojiromike
+- [#11285](https://github.com/openemr/openemr/pull/11285) chore(deps): bump picomatch from 4.0.3 to 4.0.4 in /ccdaservice — @dependabot[bot]
+- [#11287](https://github.com/openemr/openemr/pull/11287) chore(deps-dev): bump picomatch from 2.3.1 to 2.3.2 — @dependabot[bot]
+- [#11275](https://github.com/openemr/openemr/pull/11275) chore(docs): add 8.0.0.3 changelog — @kojiromike
+- [#11236](https://github.com/openemr/openemr/pull/11236) chore(deps-dev): bump rector/rector from 2.3.8 to 2.3.9 — @dependabot[bot]
+- [#11237](https://github.com/openemr/openemr/pull/11237) chore(deps): bump twig/twig from 3.23.0 to 3.24.0 — @dependabot[bot]
+- [#11238](https://github.com/openemr/openemr/pull/11238) chore(deps): bump doctrine/dbal from 4.4.2 to 4.4.3 — @dependabot[bot]
+- [#11235](https://github.com/openemr/openemr/pull/11235) chore(deps-dev): bump slevomat/coding-standard from 8.28.0 to 8.28.1 — @dependabot[bot]
+- [#11196](https://github.com/openemr/openemr/pull/11196) chore(deps-dev): bump flatted from 3.3.3 to 3.4.2 — @dependabot[bot]
+- [#11195](https://github.com/openemr/openemr/pull/11195) chore(deps): bump phpseclib/phpseclib from 3.0.49 to 3.0.50 — @dependabot[bot]
+- [#11172](https://github.com/openemr/openemr/pull/11172) chore: Rel 800 fix changelog  8.0.0.2 — @adunsulag
+- [#11104](https://github.com/openemr/openemr/pull/11104) chore: FHIR API documentation minor fixes — @stephenwaite
+- [#11101](https://github.com/openemr/openemr/pull/11101) chore: remove 2015 reference with schemaspy regen for rel-800 — @stephenwaite
+- [#11148](https://github.com/openemr/openemr/pull/11148) chore(deps): bump jspdf from 4.2.0 to 4.2.1 — @dependabot[bot]
+- [#11118](https://github.com/openemr/openemr/pull/11118) chore(deps): bump laminas/laminas-soap from 2.14.0 to 2.15.0 in the laminas group — @dependabot[bot]
+- [#11125](https://github.com/openemr/openemr/pull/11125) chore(deps): bump ckeditor5 from 47.6.0 to 47.6.1 — @dependabot[bot]
+- [#11124](https://github.com/openemr/openemr/pull/11124) chore(deps): bump mpdf/mpdf from 8.2.7 to 8.3.1 — @dependabot[bot]
+- [#11123](https://github.com/openemr/openemr/pull/11123) chore(deps): bump dompurify from 3.3.2 to 3.3.3 — @dependabot[bot]
+- [#11122](https://github.com/openemr/openemr/pull/11122) chore(deps): bump bacon/bacon-qr-code from 3.0.3 to 3.0.4 — @dependabot[bot]
+- [#11121](https://github.com/openemr/openemr/pull/11121) chore(deps): bump twilio/sdk from 8.11.1 to 8.11.2 — @dependabot[bot]
+- [#11120](https://github.com/openemr/openemr/pull/11120) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.25 to 9.0.26 — @dependabot[bot]
+- [#11119](https://github.com/openemr/openemr/pull/11119) chore(deps): bump guzzlehttp/psr7 from 2.8.0 to 2.9.0 — @dependabot[bot]
+- [#11064](https://github.com/openemr/openemr/pull/11064) chore(deps): bump predis/predis from 3.4.1 to 3.4.2 — @dependabot[bot]
+- [#11086](https://github.com/openemr/openemr/pull/11086) chore(phpstan): rebuild baseline on rel-800 — @kojiromike
+- [#11071](https://github.com/openemr/openemr/pull/11071) chore(deps): bump tar from 7.5.10 to 7.5.11 in /ccdaservice — @dependabot[bot]
+- [#11045](https://github.com/openemr/openemr/pull/11045) chore(deps): bump knockout from 3.5.1 to 3.5.2 — @dependabot[bot]
+- [#11044](https://github.com/openemr/openemr/pull/11044) chore(deps-dev): bump ramsey/conventional-commits from 1.6.0 to 1.7.0 — @dependabot[bot]
+- [#11042](https://github.com/openemr/openemr/pull/11042) chore(deps): bump dompdf/dompdf from 3.1.4 to 3.1.5 — @dependabot[bot]
+- [#11041](https://github.com/openemr/openemr/pull/11041) chore(deps): bump the symfony group with 4 updates — @dependabot[bot]
+- [#11046](https://github.com/openemr/openemr/pull/11046) chore(deps-dev): bump postcss from 8.5.6 to 8.5.8 — @dependabot[bot]
+- [#11043](https://github.com/openemr/openemr/pull/11043) chore(deps-dev): bump eslint from 9.39.3 to 9.39.4 in the build-tools group — @dependabot[bot]
+- [#11000](https://github.com/openemr/openemr/pull/11000) chore(deps): bump dompurify from 3.3.1 to 3.3.2 — @dependabot[bot]
+- [#10996](https://github.com/openemr/openemr/pull/10996) chore(deps): bump tar from 7.5.9 to 7.5.10 in /ccdaservice — @dependabot[bot]
+- [#10990](https://github.com/openemr/openemr/pull/10990) chore(deps-dev): bump immutable from 5.1.1 to 5.1.5 — @dependabot[bot]
+- [#10980](https://github.com/openemr/openemr/pull/10980) chore(deps): bump @ckeditor/ckeditor5-html-support and ckeditor5 — @dependabot[bot]
+- [#10930](https://github.com/openemr/openemr/pull/10930) chore(db): Remove most of ApplicationTable & Laminas DB coupling — @Firehed
+- [#10958](https://github.com/openemr/openemr/pull/10958) chore(deps-dev): bump phpstan/phpstan from 2.1.39 to 2.1.40 in the development group — @dependabot[bot]
+- [#10957](https://github.com/openemr/openemr/pull/10957) chore(deps): bump the symfony group with 7 updates — @dependabot[bot]
+- [#10961](https://github.com/openemr/openemr/pull/10961) chore(deps): bump zircote/swagger-php from 6.0.5 to 6.0.6 — @dependabot[bot]
+- [#10962](https://github.com/openemr/openemr/pull/10962) chore(deps): bump predis/predis from 3.4.0 to 3.4.1 — @dependabot[bot]
+- [#10963](https://github.com/openemr/openemr/pull/10963) chore(deps): bump phpoffice/phpspreadsheet from 5.4.0 to 5.5.0 — @dependabot[bot]
+- [#10964](https://github.com/openemr/openemr/pull/10964) chore(deps): bump doctrine/dbal from 4.4.1 to 4.4.2 — @dependabot[bot]
+- [#10960](https://github.com/openemr/openemr/pull/10960) chore(deps-dev): bump autoprefixer from 10.4.24 to 10.4.27 — @dependabot[bot]
+- [#10959](https://github.com/openemr/openemr/pull/10959) chore(deps): bump giggsey/libphonenumber-for-php from 9.0.23 to 9.0.25 — @dependabot[bot]
+- [#10933](https://github.com/openemr/openemr/pull/10933) chore(deps): bump minimatch — @dependabot[bot]
+- [#10880](https://github.com/openemr/openemr/pull/10880) chore(deps): bump underscore from 1.13.7 to 1.13.8 — @dependabot[bot]
+- [#10877](https://github.com/openemr/openemr/pull/10877) chore(deps): bump twilio/sdk from 8.11.0 to 8.11.1 — @dependabot[bot]
+- [#10875](https://github.com/openemr/openemr/pull/10875) chore(deps): bump jquery-validation from 1.22.0 to 1.22.1 in the jquery-bootstrap group — @dependabot[bot]
+- [#10878](https://github.com/openemr/openemr/pull/10878) chore(deps-dev): bump eslint from 9.39.2 to 9.39.3 in the build-tools group — @dependabot[bot]
+- [#10876](https://github.com/openemr/openemr/pull/10876) chore(deps-dev): bump rector/rector from 2.3.6 to 2.3.8 — @dependabot[bot]
+- [#10874](https://github.com/openemr/openemr/pull/10874) chore(deps-dev): bump phpunit/phpunit from 11.5.53 to 11.5.55 in the development group — @dependabot[bot]
+- [#10783](https://github.com/openemr/openemr/pull/10783) chore(deps): bump predis/predis from 3.3.0 to 3.4.0 — @dependabot[bot]
+- [#10802](https://github.com/openemr/openemr/pull/10802) chore(db): Convert legacy Phreeze to updated connection handling — @Firehed
+- [#10817](https://github.com/openemr/openemr/pull/10817) chore(deps): bump jspdf from 4.1.0 to 4.2.0 — @dependabot[bot]
+- [#10793](https://github.com/openemr/openemr/pull/10793) chore(deps): bump tar from 7.5.7 to 7.5.9 in /ccdaservice — @dependabot[bot]
+- [#10784](https://github.com/openemr/openemr/pull/10784) chore(deps): bump sortablejs from 1.15.6 to 1.15.7 — @dependabot[bot]
+- [#10785](https://github.com/openemr/openemr/pull/10785) chore(deps): bump i18next-browser-languagedetector from 8.2.0 to 8.2.1 — @dependabot[bot]
+- [#10782](https://github.com/openemr/openemr/pull/10782) chore(deps): bump knplabs/knp-snappy from 1.5.1 to 1.6.0 — @dependabot[bot]
+- [#10781](https://github.com/openemr/openemr/pull/10781) chore(deps-dev): bump ergebnis/composer-normalize from 2.49.0 to 2.50.0 — @dependabot[bot]
+- [#10780](https://github.com/openemr/openemr/pull/10780) chore(deps-dev): bump the development group with 5 updates — @dependabot[bot]
+- [#10732](https://github.com/openemr/openemr/pull/10732) chore(deps): bump qs from 6.14.1 to 6.14.2 in /ccdaservice — @dependabot[bot]
+- [#10515](https://github.com/openemr/openemr/pull/10515) chore: reused SingletonTrait at OEGlobalsBag — @igormukhingmailcom
+- [#10695](https://github.com/openemr/openemr/pull/10695) chore: prep changelog for 8.0.0 release — @bradymiller
+- [#10655](https://github.com/openemr/openemr/pull/10655) chore(deps): bump twilio/sdk from 8.10.1 to 8.11.0 — @dependabot[bot]
+- [#10444](https://github.com/openemr/openemr/pull/10444) chore(phpstan): Raise PHPStan level to 10; baseline new errors — @Firehed
+- [#10656](https://github.com/openemr/openemr/pull/10656) chore(deps-dev): bump rector/rector from 2.3.5 to 2.3.6 — @dependabot[bot]
+- [#10654](https://github.com/openemr/openemr/pull/10654) chore(deps-dev): bump phpunit/phpunit from 11.5.50 to 11.5.52 in the development group — @dependabot[bot]
+
+## Other
+
+- [#12781](https://github.com/openemr/openemr/pull/12781) ci(deps): bump actions/checkout from 5 to 7 — @dependabot[bot]
+- [#12780](https://github.com/openemr/openemr/pull/12780) ci(deps): bump lewagon/wait-on-check-action from 1.8.0 to 1.8.1 — @dependabot[bot]
+- [#12778](https://github.com/openemr/openemr/pull/12778) ci(docker): trigger docker-test-release on version.php bumps — @bradymiller
+- [#12774](https://github.com/openemr/openemr/pull/12774) ci(all-checks-passed): trigger on rel-* branches — @bradymiller
+- [#12720](https://github.com/openemr/openemr/pull/12720) ci(docker): trigger orchestrator on push to release-targets.yml — @bradymiller
+- [#12708](https://github.com/openemr/openemr/pull/12708) ci(claude-review): pin orchestrator to Sonnet, drop the premium Opus default — @bradymiller
+- [#12707](https://github.com/openemr/openemr/pull/12707) ci(claude-review): drop show_full_output debug flag — @bradymiller
+- [#12705](https://github.com/openemr/openemr/pull/12705) ci(claude-review): switch to Anthropic code-review plugin, on-demand only — @bradymiller
+- [#12704](https://github.com/openemr/openemr/pull/12704) ci(claude-review): allow-list GitHub comment tools + surface transcript — @bradymiller
+- [#12700](https://github.com/openemr/openemr/pull/12700) ci(claude-review): add reusable + caller workflow for PR reviews — @bradymiller
+- [#12663](https://github.com/openemr/openemr/pull/12663) ci(deps): bump actions/cache from 5 to 6 — @dependabot[bot]
+- [#12659](https://github.com/openemr/openemr/pull/12659) ci(phpstan): drop vestigial Remove Rector step — @bradymiller
+- [#12658](https://github.com/openemr/openemr/pull/12658) ci(phpstan): authenticate Composer with GITHUB_TOKEN to dodge API throttle — @bradymiller
+- [#12650](https://github.com/openemr/openemr/pull/12650) docs: note HOST_UID auto-export for transparent host-uid alignment — @bradymiller
+- [#12613](https://github.com/openemr/openemr/pull/12613) docs: document new openemr-cmd worktree add -b default and --base flag — @bradymiller
+- [#12595](https://github.com/openemr/openemr/pull/12595) docs(claude): warn against git fetch --update-head-ok in the primary repo — @bradymiller
+- [#12558](https://github.com/openemr/openemr/pull/12558) ci(deps): bump actions/checkout from 6 to 7 — @dependabot[bot]
+- [#12586](https://github.com/openemr/openemr/pull/12586) docs(ci): document release-targets.yml as master-authoritative — @bradymiller
+- [#12574](https://github.com/openemr/openemr/pull/12574) ci(pre-commit): broaden workflow to validate every upstream hook on --all-files — @bradymiller
+- [#12573](https://github.com/openemr/openemr/pull/12573) style(pre-commit): split pretty-format-json into per-ecosystem 2-space/4-space blocks — @bradymiller
+- [#12571](https://github.com/openemr/openemr/pull/12571) style(yaml): apply pretty-format-yaml across repo-owned configs — @bradymiller
+- [#12553](https://github.com/openemr/openemr/pull/12553) ci(dependabot): track pre-commit hook revs — @bradymiller
+- [#12551](https://github.com/openemr/openemr/pull/12551) docs(docker): relocate migration doc + refresh post-migration documentation — @bradymiller
+- [#12497](https://github.com/openemr/openemr/pull/12497) ci(docker): port migration to rel-704 (phase 2, lighter) — @bradymiller
+- [#12496](https://github.com/openemr/openemr/pull/12496) ci(docker): port migration to rel-800 (phase 2, lighter) — @bradymiller
+- [#12495](https://github.com/openemr/openemr/pull/12495) ci(docker): port migration to rel-810 (phase 2, full) — @bradymiller
+- [#12482](https://github.com/openemr/openemr/pull/12482) ci(docker): docker migration master-side (phases 1a + 1b + 1c) — @bradymiller
+- [#12530](https://github.com/openemr/openemr/pull/12530) test(billing): add isolated tests for Claim::procCount and payerCount — @kojiromike
+- [#12471](https://github.com/openemr/openemr/pull/12471) test(ccda): add integration test for CcdaGenerator::socket_get — @Firehed
+- [#12463](https://github.com/openemr/openemr/pull/12463) docs(claude-md): document Claude Code-driven Selenium debugging — @bradymiller
+- [#12453](https://github.com/openemr/openemr/pull/12453) build(deps): replace grunt/jshint with eslint+mocha in oe-cda-schematron — @kojiromike
+- [#12464](https://github.com/openemr/openemr/pull/12464) style(docker): normalize YAML indentation in dev-easy-redis compose — @bradymiller
+- [#11231](https://github.com/openemr/openemr/pull/11231) build(webpack): replace gulp with webpack for theme compilation — @rollingventures
+- [#12446](https://github.com/openemr/openemr/pull/12446) ci(deps): bump lewagon/wait-on-check-action from 1.7.0 to 1.8.0 — @dependabot[bot]
+- [#12445](https://github.com/openemr/openemr/pull/12445) ci: capture openemr log and apache coredump in e2e failure artifact — @kojiromike
+- [#12431](https://github.com/openemr/openemr/pull/12431) ci: authenticate to Docker Hub before image pulls to lift rate limits — @kojiromike
+- [#12425](https://github.com/openemr/openemr/pull/12425) ci: retry Docker image pulls with backoff to survive registry timeouts — @kojiromike
+- [#12406](https://github.com/openemr/openemr/pull/12406) ci(deps): bump codecov/codecov-action from 6 to 7 — @dependabot[bot]
+- [#12369](https://github.com/openemr/openemr/pull/12369) docs(worktree): document openemr-cmd worktree prune + graceful remove — @bradymiller
+- [#12372](https://github.com/openemr/openemr/pull/12372) ci(deps): migrate dependabot-auto-merge to client-id / vars — @bradymiller
+- [#12371](https://github.com/openemr/openemr/pull/12371) ci(phpstan): migrate reserved-word bot to client-id / vars — @bradymiller
+- [#12368](https://github.com/openemr/openemr/pull/12368) ci(phpstan): use GitHub App for reserved-word refresh PRs so CI runs — @bradymiller
+- [#12341](https://github.com/openemr/openemr/pull/12341) ci: also ignore codecov/patch in All Checks Passed aggregate — @bradymiller
+- [#12117](https://github.com/openemr/openemr/pull/12117) docs: add end-to-end RELEASE_PROCESS.md for automated release flow — @kojiromike
+- [#12259](https://github.com/openemr/openemr/pull/12259) test(api): align site_addr_oath with baseUrl in GroupExportFhirApiTest setUp — @bradymiller
+- [#12321](https://github.com/openemr/openemr/pull/12321) build: exclude generated EHI schema docs from release archives — @kojiromike
+- [#12317](https://github.com/openemr/openemr/pull/12317) build: exclude generated EHI schema docs from release archives — @kojiromike
+- [#12296](https://github.com/openemr/openemr/pull/12296) Revert "chore(release): prep 8.1.0" — @kojiromike
+- [#12268](https://github.com/openemr/openemr/pull/12268) test: exclude non-logic dirs from phpunit coverage — @kojiromike
+- [#12229](https://github.com/openemr/openemr/pull/12229) revert(faxsms): restore VoiceClient and in-browser RingCentral softphone — @kojiromike
+- [#12258](https://github.com/openemr/openemr/pull/12258) test: exclude NotificationCronEmailTest from e2e suite (it lives in email suite) — @bradymiller
+- [#12250](https://github.com/openemr/openemr/pull/12250) docs: document openemr-cmd phpstan-generate-reset and update-layout-field-fixtures — @bradymiller
+- [#12232](https://github.com/openemr/openemr/pull/12232) test(layout): snapshot rendered HTML for every layout field type — @kojiromike
+- [#11918](https://github.com/openemr/openemr/pull/11918) test(ci): skip data_absent_reason test in US Core 3.1.1 suite — @Firehed
+- [#12210](https://github.com/openemr/openemr/pull/12210) ci: add apache_{82,85}_118_upgrade variants exercising 5.0.0→current sql_upgrade chain — @bradymiller
+- [#12147](https://github.com/openemr/openemr/pull/12147) docs: document docker-routed pre-commit workflow + isolate PHPStan tmpDir via named volume — @bradymiller
+- [#12021](https://github.com/openemr/openemr/pull/12021) docs: document new openemr-cmd worktree subcommands and AI-assistant rules — @bradymiller
+- [#12040](https://github.com/openemr/openemr/pull/12040) ci(deps): bump actions/create-github-app-token from 1 to 3 — @dependabot[bot]
+- [#12039](https://github.com/openemr/openemr/pull/12039) ci(deps): bump peter-evans/create-pull-request from 7 to 8 — @dependabot[bot]
+- [#11896](https://github.com/openemr/openemr/pull/11896) docs: plan for openemr release-automation conductor (openemr-devops#664) — @kojiromike
+- [#12010](https://github.com/openemr/openemr/pull/12010) test: move isolated-compatible tests to isolated suite — @Firehed
+- [#11584](https://github.com/openemr/openemr/pull/11584) test(security): expand isolated tests for unserialize allowed_classes — @kojiromike
+- [#11617](https://github.com/openemr/openemr/pull/11617) ci: include composer.json in vendor cache key — @Firehed
+- [#11638](https://github.com/openemr/openemr/pull/11638) test(phpunit): fail on deprecations in all test suites — @kojiromike
+- [#11681](https://github.com/openemr/openemr/pull/11681) docs(background-services): clarify register() active-flag policy — @kojiromike
+- [#11699](https://github.com/openemr/openemr/pull/11699) test(background-services): add shell-out CLI integration test — @kojiromike
+- [#11795](https://github.com/openemr/openemr/pull/11795) test(calendar): cover recurring event repeat-type branching — @kojiromike
+- [#11796](https://github.com/openemr/openemr/pull/11796) ci(phpstan): gate fatal-category baseline entries from ever growing — @kojiromike
+- [#11816](https://github.com/openemr/openemr/pull/11816) ci(phpstan): add composer phpstan-baseline-reset to wipe and rebuild — @kojiromike
+- [#11847](https://github.com/openemr/openemr/pull/11847) ci(phpstan): make baseline-diff PR lookup tolerant of API failures — @kojiromike
+- [#11852](https://github.com/openemr/openemr/pull/11852) ci(ccdaservice): rebuild libxmljs2 from source — @kojiromike
+- [#11857](https://github.com/openemr/openemr/pull/11857) ci(e2e): capture diagnostics for InvalidSessionIdException flake — @kojiromike
+- [#11861](https://github.com/openemr/openemr/pull/11861) Revert "ci(ccdaservice): rebuild libxmljs2 from source (#11852)" — @kojiromike
+- [#11862](https://github.com/openemr/openemr/pull/11862) ci(ccdaservice): rename cache key to invalidate stale v127 binaries — @kojiromike
+- [#11986](https://github.com/openemr/openemr/pull/11986) ci: harden e2e test step against rerun cascade failure — @kojiromike
+- [#10387](https://github.com/openemr/openemr/pull/10387) perf(ci): restore file timestamps to enable PHPStan caching — @kojiromike
+- [#11832](https://github.com/openemr/openemr/pull/11832) ci(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 — @dependabot[bot]
+- [#11833](https://github.com/openemr/openemr/pull/11833) ci(deps): bump actions/download-artifact from 7 to 8 — @dependabot[bot]
+- [#11828](https://github.com/openemr/openemr/pull/11828) ci(phpstan): post baseline diff as a sticky PR comment — @kojiromike
+- [#11724](https://github.com/openemr/openemr/pull/11724) ci: key phpstan and rector caches on tool version, not composer.lock — @kojiromike
+- [#11173](https://github.com/openemr/openemr/pull/11173) Update fetch-depth in build-patch.yml — @adunsulag
+- [#11170](https://github.com/openemr/openemr/pull/11170) Conditional directory creation for patch files — @adunsulag
+- [#11158](https://github.com/openemr/openemr/pull/11158) test(crypto): add integration tests for CryptoGen decryption — @Firehed
+- [#11277](https://github.com/openemr/openemr/pull/11277) docs(contributing): update PR and contribution guidelines — @Firehed
+- [#11595](https://github.com/openemr/openemr/pull/11595) docs(api): add OpenAPI attributes to BackgroundServiceRestController — @kojiromike
+- [#11366](https://github.com/openemr/openemr/pull/11366) test(background-services): add integration tests for BackgroundServiceRegistry — @corevibe555
+- [#11286](https://github.com/openemr/openemr/pull/11286) style(custom): fix indentation in export_xml.php — @kojiromike
+- [#11342](https://github.com/openemr/openemr/pull/11342) docs(ai): expand CLAUDE.md with PHP coding standards — @kojiromike
+- [#11518](https://github.com/openemr/openemr/pull/11518) ci: pin Docker images by digest and add Dependabot for CI images — @kojiromike
+- [#11541](https://github.com/openemr/openemr/pull/11541) ci(docker): pin Docker images by digest in docker/* development environments — @kojiromike
+- [#11537](https://github.com/openemr/openemr/pull/11537) ci(deps): use patch-level tags and refine Dependabot ignore rules — @kojiromike
+- [#11536](https://github.com/openemr/openemr/pull/11536) ci(deps): allow patch updates for CI docker images — @kojiromike
+- [#11535](https://github.com/openemr/openemr/pull/11535) ci(deps): ignore version bumps for CI images pinned to specific versions — @kojiromike
+- [#10853](https://github.com/openemr/openemr/pull/10853) test: add isolated tests for search query subsystem — @kojiromike
+- [#10852](https://github.com/openemr/openemr/pull/10852) test: add isolated tests for NetworkUtils, FileUtils, HttpUtils, and DbUtils — @kojiromike
+- [#10838](https://github.com/openemr/openemr/pull/10838) test: add isolated tests for KeyVersion and PhoneNumber — @kojiromike
+- [#10835](https://github.com/openemr/openemr/pull/10835) test: add isolated tests for QDM AbstractType — @kojiromike
+- [#10828](https://github.com/openemr/openemr/pull/10828) test: add isolated tests for QueryPagination and BoundFilter — @kojiromike
+- [#10836](https://github.com/openemr/openemr/pull/10836) test: add isolated tests for PlaceOfServiceEnum and DateHelper — @kojiromike
+- [#10832](https://github.com/openemr/openemr/pull/10832) test: add isolated tests for BmiCategory and ScopePermissionObject — @kojiromike
+- [#11079](https://github.com/openemr/openemr/pull/11079) ci: add Build Patch Release workflow — @kojiromike
+- [#10768](https://github.com/openemr/openemr/pull/10768) ci: add check for v_database alignment between version.php and database.sql — @kojiromike
+- [#11239](https://github.com/openemr/openemr/pull/11239) ci(deps): add rector and shipmonk to dependabot development group — @kojiromike
+- [#10987](https://github.com/openemr/openemr/pull/10987) test(isolated): add EncounterRestController tests — @kojiromike
+- [#10974](https://github.com/openemr/openemr/pull/10974) test(isolated): add coverage for 7 previously untested classes — @kojiromike
+- [#10641](https://github.com/openemr/openemr/pull/10641) test(coverage): exclude uncoverable test infrastructure from coverage — @kojiromike
+- [#10648](https://github.com/openemr/openemr/pull/10648) ci(codecov): report every time — @kojiromike
+- [#10953](https://github.com/openemr/openemr/pull/10953) docs(contributing): add guidance on proposing changes and repo selection — @kojiromike
+- [#10940](https://github.com/openemr/openemr/pull/10940) docs(api): fix copy-paste errors in OpenAPI annotations — @kojiromike
+- [#10915](https://github.com/openemr/openemr/pull/10915) test(services): add AppointmentService test coverage — @craigrallen
+- [#10825](https://github.com/openemr/openemr/pull/10825) test(utils): add isolated tests for MeasurementUtils and StringUtils — @kojiromike
+- [#11062](https://github.com/openemr/openemr/pull/11062) ci(deps): bump actions/download-artifact from 4 to 8 — @dependabot[bot]
+- [#11040](https://github.com/openemr/openemr/pull/11040) ci(deps): bump docker/login-action from 3 to 4 — @dependabot[bot]
+- [#11039](https://github.com/openemr/openemr/pull/11039) ci(deps): bump docker/setup-qemu-action from 3 to 4 — @dependabot[bot]
+- [#11175](https://github.com/openemr/openemr/pull/11175) ci(build-patch): delete .github/workflows/build-patch.yml — @kojiromike
+- [#11038](https://github.com/openemr/openemr/pull/11038) ci(deps): bump docker/build-push-action from 6 to 7 — @dependabot[bot]
+- [#11037](https://github.com/openemr/openemr/pull/11037) ci(deps): bump docker/setup-buildx-action from 3 to 4 — @dependabot[bot]
+- [#10873](https://github.com/openemr/openemr/pull/10873) test(cda): add isolated unit tests for CdaTemplateParse — @kojiromike
+- [#11232](https://github.com/openemr/openemr/pull/11232) ci(deps): bump j178/prek-action from 1 to 2 — @dependabot[bot]
+- [#10831](https://github.com/openemr/openemr/pull/10831) test(menu): add isolated tests for MenuItems and BaseMenuItem — @kojiromike
+- [#10653](https://github.com/openemr/openemr/pull/10653) ci(deps): bump actions/upload-artifact from 4 to 6 — @dependabot[bot]
+- [#10956](https://github.com/openemr/openemr/pull/10956) ci(deps): bump actions/upload-artifact from 6 to 7 — @dependabot[bot]
+- [#11030](https://github.com/openemr/openemr/pull/11030) test(api): enable isolated SiteSetupListener tests — @kojiromike
+- [#11051](https://github.com/openemr/openemr/pull/11051) perf(ci): parallelize test suites within each configuration — @kojiromike
+- [#11010](https://github.com/openemr/openemr/pull/11010) docs: document OEGlobalsBag typed getters from ParameterBag — @kojiromike
+- [#10979](https://github.com/openemr/openemr/pull/10979) docs: update CLAUDE.md for recent codebase changes — @kojiromike
+- [#11351](https://github.com/openemr/openemr/pull/11351) ci(deps): bump codecov/codecov-action from 5 to 6 — @dependabot[bot]
+- [#11028](https://github.com/openemr/openemr/pull/11028) test(csrf): add CSRF token round-trip tests with Symfony session — @kojiromike
+- [#10872](https://github.com/openemr/openemr/pull/10872) test: add isolated tests for EDI270, event DTOs, Metadata, and oeHttpResponse — @kojiromike
+- [#10484](https://github.com/openemr/openemr/pull/10484) docs(api): add CLI testing tip for special characters in passwords — @fzzio
+

--- a/static/documentation/8.2.0/b10/columns.html
+++ b/static/documentation/8.2.0/b10/columns.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a01be80b430fada655ba212f2168fe3ed9714216b3db4365e44e5c920f12b884
+oid sha256:7c8a88455bf2093e63462ff2263b1e254ec86cecbe98fababc1d51cd813d6c98
 size 1168717

--- a/static/documentation/8.2.0/b10/index.html
+++ b/static/documentation/8.2.0/b10/index.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72cac768cd0ed52060495607efc0e2095b6f1e59cc9e9fa8c201bd8d3afddf46
+oid sha256:0de022b2d504f10e778757bfb07f5b137c8120d1a3d3a79752a429b57052d59f
 size 136936

--- a/static/documentation/8.2.0/b10/info-html.txt
+++ b/static/documentation/8.2.0/b10/info-html.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a396e6e5c37d4dde1b0a46b7ce02242e11f500677db5fa67d6bf25ef3aaaf48a
+oid sha256:b78978ac208dc28f4f3cfc904e05f6072925cef3f950ff92a624de4f11675633
 size 198


### PR DESCRIPTION
Manual recovery PR for 8.2.0's acknowledgements + release-notes content.

## Background

The original release-docs PR (#164) landed the FINAL 8.2.0 entry into `data/releases.json` but did NOT include acknowledgements or release-notes markdown files — because the FINAL `openemr-tag` dispatch fired without \`prev_release\`, gating those two generators to SKIPPED. See gap G20.

A recovery dispatch fired today (2026-07-09) using \`event=openemr-rel-update\` (which accepts \`prev_release=8.0.0\` per schema) — both generators ran successfully this time. The workflow's \`upsert-pr\` task then hit an edge case: \`gh pr view <branch>\` matched the merged #164 and ran \`gh pr edit\` on it instead of \`gh pr create\`. Opening manually as a follow-up.

## Contents

- \`content/acknowledgements/8.2.0.md\` (new, added by \`gen-acknowledgements\`)
- \`content/release-notes/8.2.0.md\` (new, added by \`gen-release-notes\` with #173's dependabot/openemr-images filter applied)
- \`static/documentation/8.2.0/b10/\` (b10 SchemaSpy tree, regenerated)
- \`data/releases.json\` (no-op — same content already on master)

## Follow-ups tracked in gaps doc

- G20 — 3-place fix (schema + jq + openemr-side emitter) to fix openemr-tag path so this can't happen again on future FINAL cuts.
- G22 — port #173 filter algorithm to openemr/openemr's CHANGELOG.md + GitHub Release body generation. Once that lands, this per-version release-notes markdown on master becomes redundant and can be dropped.
- Workflow bug — \`workflow:upsert-pr\` should distinguish between open vs closed/merged PRs for the same branch. Currently a merged PR silently absorbs the intended new-PR-create.