### PR TITLE
feat(downloads,releases): link per-version acknowledgements page when present

### DIFF
--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -117,6 +117,9 @@
                         {{ else }}
                             <li><a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">Release notes (GitHub)</a></li>
                         {{ end }}
+                        {{ with site.GetPage (printf "/acknowledgements/%s" .version) }}
+                            <li><a href="{{ .Permalink }}">Acknowledgements</a></li>
+                        {{ end }}
                         <li><a href="https://www.open-emr.org/wiki/index.php/OpenEMR_ONC_Ambulatory_EHR_Certification_Requirements">ONC Ambulatory EHR certification resources</a></li>
                     </ul>
                 {{ end }}

--- a/layouts/section/releases.html
+++ b/layouts/section/releases.html
@@ -87,6 +87,9 @@
                             {{ else }}
                                 <a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">notes (GitHub)</a>
                             {{ end }}
+                            {{ with site.GetPage (printf "/acknowledgements/%s" .version) }}
+                                &nbsp;|&nbsp;<a href="{{ .Permalink }}">acknowledgements</a>
+                            {{ end }}
                         </td>
                         <td>
                             {{ with $tarballUrl }}<a href="{{ . }}">tar.gz</a>{{ end }}


### PR DESCRIPTION
## Summary

Adds per-version acknowledgements links to `/downloads/` and `/releases/`, with graceful degradation when the target page doesn't exist.

- **`/downloads/`** — adds an `Acknowledgements` `<li>` to the current stable release's "What's in this release" list. Only rendered when the page exists.
- **`/releases/`** — inlines the acknowledgements link in each row's Release notes cell as `notes | acknowledgements`. Only rendered when the page exists.

Both use `site.GetPage "/acknowledgements/<version>"` so pre-mechanism releases without generated acknowledgements pages simply don't render the link.

## Why now

`content/acknowledgements/8.2.0.md` landed on master via #181 (openemr-rel-update recovery dispatch). Before this PR, that page was accessible only by typing the URL directly — no layout on the site linked to it.

## Scope

Partial fix for the acknowledgements half of **G21** in the release-mechanism-gaps doc. The release-notes half (retargeting layout links to the GitHub Release URL and dropping the website's per-version release-notes as a landing surface) is intentionally deferred — G22 upstream work needs to land first (port the #173 dependabot filter to openemr/openemr's CHANGELOG.md + GitHub Release body generation) before the GitHub Release becomes a quality-equivalent replacement.

## Test plan

- [ ] Preview build renders 8.2.0's acknowledgements link on both `/downloads/` and `/releases/` (pointing at `/acknowledgements/8.2.0/`).
- [ ] Pre-mechanism releases (8.0.0, 7.0.4, etc.) do NOT render the link — the row/list stays quiet.