### PR TITLE
chore(demo): bump demo page version references to 8.2.0

### DIFF
--- a/content/demo/_index.md
+++ b/content/demo/_index.md
@@ -6,7 +6,7 @@ layout: page
 external_links_new_tab: true
 ---
 
-# Fully Working OpenEMR 8.0.0 Demo
+# Fully Working OpenEMR 8.2.0 Demo
 
 We offer 3 fully functional demo installations for you to try out. Some simple configuration has been added for clearer demonstration of OpenEMR, medical billing, accounting, access controls and patient portal. Each demo is reset overnight (8:00 am UTC time) so no data is persistent. Note there are 3 identical demos ('Main', 'Alternate', 'Another Alternate') offered in case a demo is down or has been modified. We also offer [Development Demos](https://www.open-emr.org/wiki/index.php/Development_Demo) (these are demos that are rebuilt daily from most recent development code) where you can test out new features.
 
@@ -35,7 +35,7 @@ Part of our mission is making OpenEMR accessible to everyone, regardless of tech
 ### Links
 | Demo                    |Link |
 |-------------------------|----------------------------------------------------------------------------------|
-| OpenEMR 8.0.0 Main Demo | [https://demo.openemr.io/openemr](https://demo.openemr.io/openemr/index.php) |
+| OpenEMR 8.2.0 Main Demo | [https://demo.openemr.io/openemr](https://demo.openemr.io/openemr/index.php) |
 | Alternate Demo          | [https://demo.openemr.io/a/openemr](https://demo.openemr.io/a/openemr/index.php) |
 | Another Alternate Demo  | [https://demo.openemr.io/b/openemr](https://demo.openemr.io/b/openemr/index.php) |
 
@@ -54,7 +54,7 @@ Part of our mission is making OpenEMR accessible to everyone, regardless of tech
 
 | Demo                      |Link |
 |---------------------------|----------------------------------------------------------------------------------------------------|
-| OpenEMR 8.0.0 Portal Demo | [https://demo.openemr.io/openemr/portal](https://demo.openemr.io/openemr/portal/index.php) |
+| OpenEMR 8.2.0 Portal Demo | [https://demo.openemr.io/openemr/portal](https://demo.openemr.io/openemr/portal/index.php) |
 | Alternate Demo            | [https://demo.openemr.io/a/openemr/portal](https://demo.openemr.io/a/openemr/portal/index.php) |
 | Another Alternate Demo    | [https://demo.openemr.io/b/openemr/portal](https://demo.openemr.io/b/openemr/portal/index.php) |
 


### PR DESCRIPTION
## Summary

Manual bump of the three demo-page references from 8.0.0 → 8.2.0 now that 8.2.0 has shipped:

- H1 heading (`# Fully Working OpenEMR 8.2.0 Demo`)
- Main demo table row (`OpenEMR 8.2.0 Main Demo | ...`)
- Portal demo table row (`OpenEMR 8.2.0 Portal Demo | ...`)

The rest of the content (URLs, credentials, alternate/portal instructions) is version-agnostic and doesn't need to change.

## Follow-up gap

Tracked as **G24** in `release-mechanism-gaps.md`: this bump should become part of the automated release surface. Two design options:

1. **Data-driven at render time** — replace the hardcoded version strings with a shortcode that reads `.Site.Data.releases` and picks the latest FINAL entry. Then future bumps happen automatically the moment a new FINAL entry lands in `data/releases.json` (via the release-docs PR merge).
2. **Auto-updated at release-docs dispatch time** — the release-docs workflow rewrites the demo page's version strings when it detects a new FINAL version, alongside the existing per-version content generation.

Option 1 is simpler + preserves single-source-of-truth. Option 2 requires adding logic to `release-docs.yml` and touching this file on every release-cut regen. Preference for option 1.