### PR TITLE
feat(downloads,releases): link changelog release asset when it exists

### DIFF
--- a/layouts/section/downloads.html
+++ b/layouts/section/downloads.html
@@ -117,6 +117,9 @@
                         {{ else }}
                             <li><a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">Release notes (GitHub)</a></li>
                         {{ end }}
+                        {{ if .entry.sha }}
+                            <li><a href="https://github.com/openemr/openemr/releases/download/{{ $tag }}/changelog.md">Changelog</a></li>
+                        {{ end }}
                         {{ with site.GetPage (printf "/acknowledgements/%s" .version) }}
                             <li><a href="{{ .Permalink }}">Acknowledgements</a></li>
                         {{ end }}

--- a/layouts/section/releases.html
+++ b/layouts/section/releases.html
@@ -87,6 +87,9 @@
                             {{ else }}
                                 <a href="https://github.com/openemr/openemr/releases/tag/{{ $tag }}">notes (GitHub)</a>
                             {{ end }}
+                            {{ if .entry.sha }}
+                                &nbsp;|&nbsp;<a href="https://github.com/openemr/openemr/releases/download/{{ $tag }}/changelog.md">changelog</a>
+                            {{ end }}
                             {{ with site.GetPage (printf "/acknowledgements/%s" .version) }}
                                 &nbsp;|&nbsp;<a href="{{ .Permalink }}">acknowledgements</a>
                             {{ end }}


### PR DESCRIPTION
## Summary

Adds a `Changelog` link on `/downloads/` and `/releases/` pointing at the `changelog.md` release asset attached to modern GitHub Releases, gated on `.entry.sha` presence so pre-mechanism entries stay quiet.

- **`/downloads/`** — new `<li><a>Changelog</a></li>` in the "What's in this release" list for the current stable release. Renders after Release notes (GitHub) and before Acknowledgements.
- **`/releases/`** — inlined into the per-row Release notes cell as `notes | changelog | acknowledgements`.
- URL pattern: `https://github.com/openemr/openemr/releases/download/${tag}/changelog.md`

## Why

`changelog.md` gets uploaded as a release asset on every dispatch-managed cut (verified: v8_0_0_3, v8_1_0, v8_2_0 all carry it). It's the full compiled changelog file — a downloadable, grep-able artifact that complements (not duplicates) the web-only auto-generated GitHub Release body. Users who want to save/search changelogs offline can now discover the asset from the website's per-version rows.

## Gate

`{{ if .entry.sha }}` — dispatch-managed release-targets entries have a git sha field; grandfathered pre-mechanism entries (8.0.0 with `archive_urls`, SourceForge-era 7.x/6.x) don't. Matches the same gate pattern already used for tarball/zip URL derivation elsewhere in these templates.

## Test plan

- [ ] Preview build renders `Changelog` link on 8.2.0 rows (both pages), pointing at `https://github.com/openemr/openemr/releases/download/v8_2_0/changelog.md`.
- [ ] Pre-mechanism releases (grandfathered 8.0.0, 7.0.4, etc.) do NOT render the Changelog link — cell stays with just `notes (wiki)`.