### PR TITLE
feat(demo): auto-derive current stable version from data/releases.json

### DIFF
--- a/content/demo/_index.md
+++ b/content/demo/_index.md
@@ -6,7 +6,7 @@ layout: page
 external_links_new_tab: true
 ---
 
-# Fully Working OpenEMR 8.2.0 Demo
+# Fully Working OpenEMR {{< current-stable-version >}} Demo
 
 We offer 3 fully functional demo installations for you to try out. Some simple configuration has been added for clearer demonstration of OpenEMR, medical billing, accounting, access controls and patient portal. Each demo is reset overnight (8:00 am UTC time) so no data is persistent. Note there are 3 identical demos ('Main', 'Alternate', 'Another Alternate') offered in case a demo is down or has been modified. We also offer [Development Demos](https://www.open-emr.org/wiki/index.php/Development_Demo) (these are demos that are rebuilt daily from most recent development code) where you can test out new features.
 
@@ -35,7 +35,7 @@ Part of our mission is making OpenEMR accessible to everyone, regardless of tech
 ### Links
 | Demo                    |Link |
 |-------------------------|----------------------------------------------------------------------------------|
-| OpenEMR 8.2.0 Main Demo | [https://demo.openemr.io/openemr](https://demo.openemr.io/openemr/index.php) |
+| OpenEMR {{< current-stable-version >}} Main Demo | [https://demo.openemr.io/openemr](https://demo.openemr.io/openemr/index.php) |
 | Alternate Demo          | [https://demo.openemr.io/a/openemr](https://demo.openemr.io/a/openemr/index.php) |
 | Another Alternate Demo  | [https://demo.openemr.io/b/openemr](https://demo.openemr.io/b/openemr/index.php) |
 
@@ -54,7 +54,7 @@ Part of our mission is making OpenEMR accessible to everyone, regardless of tech
 
 | Demo                      |Link |
 |---------------------------|----------------------------------------------------------------------------------------------------|
-| OpenEMR 8.2.0 Portal Demo | [https://demo.openemr.io/openemr/portal](https://demo.openemr.io/openemr/portal/index.php) |
+| OpenEMR {{< current-stable-version >}} Portal Demo | [https://demo.openemr.io/openemr/portal](https://demo.openemr.io/openemr/portal/index.php) |
 | Alternate Demo            | [https://demo.openemr.io/a/openemr/portal](https://demo.openemr.io/a/openemr/portal/index.php) |
 | Another Alternate Demo    | [https://demo.openemr.io/b/openemr/portal](https://demo.openemr.io/b/openemr/portal/index.php) |
 

--- a/layouts/shortcodes/current-stable-version.html
+++ b/layouts/shortcodes/current-stable-version.html
@@ -1,0 +1,31 @@
+{{- /*
+  current-stable-version — returns the highest-version FINAL entry from
+  data/releases.json as a plain version string (e.g., "8.2.0"). Used in
+  places that hardcode the current stable version in marketing copy
+  (demo page headings, table rows), so the manifest becomes the single
+  source of truth and no manual bump is needed on ship.
+
+  Usage in content:
+    OpenEMR {{< current-stable-version >}} Demo
+
+  Reads from data/releases.json (see data/releases.schema.json). The
+  release-docs workflow keeps the manifest in sync with the conductor's
+  branch state, so the page updates automatically when a new FINAL
+  release lands. Prerelease-only versions (status != FINAL) are ignored,
+  so an aborted cut like v8_1_0 doesn't briefly become the "current
+  stable" between its cut and the next real release.
+
+  Returns empty when no FINAL entries exist -- a data-corruption case
+  that would be visibly broken on the page (e.g., "OpenEMR  Demo") and
+  should surface fast rather than get papered over with a fallback.
+*/ -}}
+{{- $finals := slice -}}
+{{- range $version, $entry := .Site.Data.releases -}}
+  {{- if eq $entry.status "FINAL" -}}
+    {{- $finals = $finals | append (dict "version" $version) -}}
+  {{- end -}}
+{{- end -}}
+{{- $finals = sort $finals "version" "desc" -}}
+{{- if gt (len $finals) 0 -}}
+  {{- (index $finals 0).version -}}
+{{- end -}}


### PR DESCRIPTION
Fixes **G24** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md).

## Summary

Adds a \`current-stable-version\` Hugo shortcode that reads \`data/releases.json\`, filters for \`status: FINAL\` entries, and returns the highest-version FINAL entry as a plain string (e.g., \`8.2.0\`). Replaces the three hardcoded version strings on the demo page (H1 heading + main demo table row + portal demo table row) with the shortcode so the page updates automatically when a new FINAL release lands in \`data/releases.json\`.

## Motivation

The demo page's version strings were previously manually bumped every release cycle — three hand-edits per ship (see #183 for the 8.2.0 bump: \`s/8.0.0/8.2.0/g\` in three places). With the release-docs workflow keeping \`data/releases.json\` authoritative on shipped versions, the demo page can just read from it directly. No workflow logic added — pure render-time derivation.

## Design details

- **Filter**: only \`status: FINAL\` entries. Prerelease-only versions (\`status: DRAFT\` and everything else) are ignored so an aborted cut like \`v8_1_0\` doesn't briefly become the \"current stable\" between its cut and the next real release.
- **Sort**: descending by version key. \`data/releases.json\`'s keys are semver strings (\`8.0.0\`, \`8.2.0\`), which sort correctly under Hugo's default string sort at these version depths. If we ever need more sophisticated compare (e.g., \`10.0.0\` vs \`9.0.0\`), Hugo's \`compare.CompareStrings\` or a version-parsing helper can be added — not needed today.
- **Fallback**: empty. If no FINAL entries exist (a data-corruption case that shouldn't happen), the page renders \"OpenEMR  Demo\" — visibly broken, surfaces fast. Preferred over a hardcoded fallback that would silently mask the corruption.

## Changes

- Adds \`layouts/shortcodes/current-stable-version.html\` (new file, 24 lines).
- Replaces three hardcoded \`8.2.0\` references in \`content/demo/_index.md\` with \`{{< current-stable-version >}}\`.

Alternate demos + portal demos are version-agnostic (no per-version demo host); only the three version-string references needed conversion.

## Test plan

- [ ] Preview build renders \`OpenEMR 8.2.0 Demo\` heading + \`OpenEMR 8.2.0 Main Demo\` + \`OpenEMR 8.2.0 Portal Demo\` table entries (matches current live behavior).
- [ ] Simulate a future release by locally adding a \`\"8.3.0\": {\"status\": \"FINAL\", ...}\` entry to \`data/releases.json\` and rebuild — page should now render \`OpenEMR 8.3.0 Demo\` without any content edits.
- [ ] Confirm alternate/portal entries remain version-agnostic.

## Follow-up

Marks G24 SHIPPED once merged. The migration doc's \"bring devops release stuff to core\" section already captures the broader theme of auto-deriving downstream state from \`data/releases.json\` / \`release-targets.yml\` (parallels G6 for demo_farm_openemr).