### PR TITLE
feat(release-docs): drop non-`[bot]` non-human authors (Copilot) from acknowledgements

### DIFF
--- a/tools/release-docs/src/AcknowledgementsGenerator.php
+++ b/tools/release-docs/src/AcknowledgementsGenerator.php
@@ -18,26 +18,48 @@ use Symfony\Component\Process\Process;
 
 final class AcknowledgementsGenerator
 {
+    /**
+     * Bare author names dropped from the acknowledgements page in addition
+     * to the `[bot]`-suffix rule handled by filterAutomatedAuthors below.
+     * GitHub App identities carry the `[bot]` suffix and are caught by
+     * that rule; LLM assistants and IDE tools like Copilot commit under
+     * a bare name with no `[bot]` marker and slip through unless listed
+     * here. Add new entries as new non-human commit-author strings appear
+     * in the wild.
+     *
+     * @var list<string>
+     */
+    private const NON_HUMAN_NAMES = ['Copilot'];
+
     public function generate(string $repoPath, string $fromRev, string $toRev, string $version): string
     {
-        return $this->render($this->filterBots($this->shortlog($repoPath, $fromRev, $toRev)), $version);
+        return $this->render($this->filterAutomatedAuthors($this->shortlog($repoPath, $fromRev, $toRev)), $version);
     }
 
     /**
-     * Drop GitHub App bot authors (identified by the `[bot]` suffix that
-     * GitHub attaches to App identities in commit author metadata, e.g.
-     * `dependabot[bot]`, `openemr-reserved-word-bot[bot]`). The
-     * acknowledgements page celebrates human contributors; bot commit
-     * volume swamps the top of the list without carrying that meaning.
+     * Drop automated non-human authors from the acknowledgements input:
+     *
+     *   1. GitHub App identities, identified by the `[bot]` suffix that
+     *      GitHub attaches to App accounts in commit author metadata
+     *      (e.g. `dependabot[bot]`, `openemr-reserved-word-bot[bot]`).
+     *   2. A hand-curated list of non-`[bot]` non-humans, held in
+     *      NON_HUMAN_NAMES -- LLM assistants (Copilot) and IDE tools
+     *      that commit under a bare name with no bot suffix.
+     *
+     * The acknowledgements page celebrates human contributors; automated
+     * commit volume swamps the top of the list without carrying that
+     * meaning.
      *
      * @param list<array{name: string, commits: int}> $authors
      * @return list<array{name: string, commits: int}>
      */
-    public function filterBots(array $authors): array
+    public function filterAutomatedAuthors(array $authors): array
     {
         return array_values(array_filter(
             $authors,
-            static fn (array $author): bool => !str_ends_with($author['name'], '[bot]'),
+            static fn (array $author): bool =>
+                !str_ends_with($author['name'], '[bot]')
+                && !in_array($author['name'], self::NON_HUMAN_NAMES, true),
         ));
     }
 

--- a/tools/release-docs/tests/AcknowledgementsGeneratorTest.php
+++ b/tools/release-docs/tests/AcknowledgementsGeneratorTest.php
@@ -36,9 +36,9 @@ final class AcknowledgementsGeneratorTest extends TestCase
         );
     }
 
-    public function testFilterBotsDropsBotAuthorsAndReindexes(): void
+    public function testFilterAutomatedAuthorsDropsBotAuthorsAndReindexes(): void
     {
-        $authors = (new AcknowledgementsGenerator())->filterBots([
+        $authors = (new AcknowledgementsGenerator())->filterAutomatedAuthors([
             ['name' => 'Test Author One', 'commits' => 142],
             ['name' => 'dependabot[bot]', 'commits' => 87],
             ['name' => 'Test Author Two', 'commits' => 54],
@@ -54,12 +54,12 @@ final class AcknowledgementsGeneratorTest extends TestCase
         );
     }
 
-    public function testFilterBotsOnlyMatchesTrailingBotSuffix(): void
+    public function testFilterAutomatedAuthorsOnlyMatchesTrailingBotSuffix(): void
     {
         // A hypothetical human contributor whose display name happens to
         // contain "[bot]" in the middle isn't dropped; only the trailing-
         // suffix pattern (used by GitHub App identities) is filtered.
-        $authors = (new AcknowledgementsGenerator())->filterBots([
+        $authors = (new AcknowledgementsGenerator())->filterAutomatedAuthors([
             ['name' => 'Alice [bot maintainer] Smith', 'commits' => 5],
             ['name' => 'noisy[bot]', 'commits' => 100],
         ]);
@@ -70,10 +70,54 @@ final class AcknowledgementsGeneratorTest extends TestCase
         );
     }
 
+    public function testFilterAutomatedAuthorsDropsNonBotNonHumans(): void
+    {
+        // Copilot (and other future LLM/IDE assistants) commit under a
+        // bare name with no `[bot]` suffix, so the bot-suffix rule alone
+        // wouldn't catch them. The NON_HUMAN_NAMES blocklist handles
+        // that case -- Copilot's ~16 commits on the 8.2.0 release cycle
+        // were the concrete driver for adding it (see G25 in the
+        // openemr/openemr release-mechanism-gaps doc).
+        $authors = (new AcknowledgementsGenerator())->filterAutomatedAuthors([
+            ['name' => 'Test Author One', 'commits' => 142],
+            ['name' => 'Copilot', 'commits' => 16],
+            ['name' => 'Test Author Two', 'commits' => 54],
+        ]);
+
+        self::assertSame(
+            [
+                ['name' => 'Test Author One', 'commits' => 142],
+                ['name' => 'Test Author Two', 'commits' => 54],
+            ],
+            $authors,
+        );
+    }
+
+    public function testFilterAutomatedAuthorsPreservesNamesThatMerelyContainNonHumanSubstring(): void
+    {
+        // A hypothetical human contributor whose display name is a
+        // superset of the blocklist entry (case matters, and only exact
+        // full-name matches are dropped) is preserved. Only exact-match
+        // membership in NON_HUMAN_NAMES triggers the drop.
+        $authors = (new AcknowledgementsGenerator())->filterAutomatedAuthors([
+            ['name' => 'Copilot Enthusiast', 'commits' => 5],
+            ['name' => 'copilot', 'commits' => 3],
+            ['name' => 'Copilot', 'commits' => 100],
+        ]);
+
+        self::assertSame(
+            [
+                ['name' => 'Copilot Enthusiast', 'commits' => 5],
+                ['name' => 'copilot', 'commits' => 3],
+            ],
+            $authors,
+        );
+    }
+
     public function testRenderMatchesFixtureSnapshotAfterBotFilter(): void
     {
         $generator = new AcknowledgementsGenerator();
-        $authors = $generator->filterBots(
+        $authors = $generator->filterAutomatedAuthors(
             $generator->parseShortlog(self::loadFixture('shortlog-8.0.0-to-8.1.0.txt')),
         );
 
@@ -85,7 +129,7 @@ final class AcknowledgementsGeneratorTest extends TestCase
     public function testRenderIsDeterministic(): void
     {
         $generator = new AcknowledgementsGenerator();
-        $authors = $generator->filterBots(
+        $authors = $generator->filterAutomatedAuthors(
             $generator->parseShortlog(self::loadFixture('shortlog-8.0.0-to-8.1.0.txt')),
         );
 


### PR DESCRIPTION
Fixes **G25** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md).

## Summary

Extends the acknowledgements author-drop rule from just the \`[bot]\` suffix pattern (#172) to also cover automated commit identities that don't carry that suffix. Concrete driver: GitHub Copilot's ~16 commits on the 8.2.0 release cycle put the string \`Copilot\` at the top of \`content/acknowledgements/8.2.0.md\` alongside real human contributors, because Copilot commits under a bare name with no \`[bot]\` marker.

## Changes

**\`tools/release-docs/src/AcknowledgementsGenerator.php\`**:
- Renames \`filterBots()\` → \`filterAutomatedAuthors()\`. \`filterBots\` became a misnomer once the rule covered non-bot non-humans; the new name reflects what the method actually does.
- Adds \`NON_HUMAN_NAMES = ['Copilot']\` private constant. New automated commit-author strings can be appended here as they appear in the wild — kept as a hand-curated blocklist rather than a pattern because non-bot non-humans have no shared marker.
- Filter closure now drops authors whose name is either \`[bot]\`-suffixed OR exact-match a \`NON_HUMAN_NAMES\` entry.

**\`tools/release-docs/tests/AcknowledgementsGeneratorTest.php\`**:
- Renames the two existing \`testFilterBots*\` tests.
- Adds a positive test (Copilot dropped, humans preserved).
- Adds a negative test — exact-match only: \`Copilot Enthusiast\` and \`copilot\` (different case) are **not** dropped. Only full-name exact match triggers the block.

## Scope

Prospective fix. \`content/acknowledgements/8.2.0.md\` was already generated with the Copilot entry via #181's recovery dispatch and is unaffected by this change. Recovery options for the 8.2.0 page (hand-edit vs. re-dispatch after this lands) are captured in openemr/openemr's release-mechanism-gaps doc under G25.

## Test plan

- [ ] CI runs the phpunit suite (5 tests pass — 2 existing renamed, 2 new)
- [ ] Preview build of a future release-docs dispatch confirms Copilot no longer appears in acknowledgements output