### PR TITLE
fix(release-docs): filter workflow:upsert-pr to state=open before edit-vs-create

### DIFF
--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -295,8 +295,20 @@ tasks:
           printf 'This PR is force-updated on every dispatch. Do not push commits\n'
           printf 'directly — they will be overwritten.\n'
         } > "$body_file"
-        if gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json number >/dev/null 2>&1; then
-          gh pr edit "$BRANCH" --repo "$GITHUB_REPOSITORY" \
+        # Filter by --state open so a previously-merged PR for the same
+        # branch (typical after a recovery dispatch on a release-docs
+        # branch whose original PR already shipped) doesn't get matched
+        # here and silently absorbed by `gh pr edit` -- editing a merged
+        # PR is a no-op for the intent, leaves the freshly force-pushed
+        # branch unattached to any live PR, and reports success while
+        # doing nothing. Capture the PR number explicitly so `gh pr edit`
+        # can't ambiguously fall back to a closed/merged match if the
+        # `--head`/`--state` combination ever returns multiple.
+        open_pr="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+          --head "$BRANCH" --state open --json number \
+          --jq '.[0].number // empty')"
+        if [ -n "$open_pr" ]; then
+          gh pr edit "$open_pr" --repo "$GITHUB_REPOSITORY" \
             --title "$title" --body-file "$body_file"
         else
           gh pr create --draft --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
Fixes **G23** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md).

## Problem

\`workflow:upsert-pr\` guarded create-vs-edit on the mere presence of ANY PR for the branch:

\`\`\`bash
if gh pr view "\$BRANCH" ... --json number >/dev/null 2>&1; then
  gh pr edit "\$BRANCH" ...
else
  gh pr create --draft ...
fi
\`\`\`

\`gh pr view <branch>\` returns the most recent PR for the head branch regardless of state, so a **merged** PR for \`release-docs/<version>\` (typical after the release's initial docs PR already shipped) matched here. The task then ran \`gh pr edit\` on the merged PR — a silent no-op for the intent: a merged PR can't be reopened or receive new commits, and the freshly force-pushed branch sits unattached to any live PR. The workflow step reports success while doing nothing.

## Concrete surface

**2026-07-09 recovery dispatch for 8.2.0** (after openemr/openemr#12868's initial fix): the workflow ran cleanly and both generators produced content, but this task's \`gh pr view\` matched the merged 8.2.0 docs PR (#164). \`gh pr edit #164\` was a no-op and no new PR opened. Recovery required manual \`gh pr create\` (#181) to attach the force-pushed branch.

## Fix

Use \`gh pr list --head "\$BRANCH" --state open\` and capture the resulting PR number explicitly:

\`\`\`bash
open_pr="\$(gh pr list --repo "\$GITHUB_REPOSITORY" \\
  --head "\$BRANCH" --state open --json number \\
  --jq '.[0].number // empty')"
if [ -n "\$open_pr" ]; then
  gh pr edit "\$open_pr" --repo "\$GITHUB_REPOSITORY" \\
    --title "\$title" --body-file "\$body_file"
else
  gh pr create --draft --repo "\$GITHUB_REPOSITORY" \\
    --base master --head "\$BRANCH" \\
    --title "\$title" --body-file "\$body_file"
fi
\`\`\`

- When no open PR exists → \`gh pr create --draft\` regardless of whether merged/closed PRs are associated with the branch.
- When one does → \`gh pr edit\` addresses it by explicit PR number so no branch-name ambiguity remains.

## Trigger surface

Any \`release-docs/<version>\` branch that gets regenerated after its PR has merged:
- Recovery dispatches (the concrete 8.2.0 case)
- Post-merge re-fires for a version that already shipped
- Any future flow that force-pushes into \`release-docs/<version>\` after its PR closed

## Test plan

- [ ] CI covers this task via the release-docs-ci workflow
- [ ] Manual verification path (not required for merge): trigger a recovery dispatch on any already-shipped version, confirm a NEW PR is opened (not the old merged one edited)