### PR TITLE
ci(deps): bump arduino/setup-task v2 → v3 across release-docs workflows

### DIFF
--- a/.github/workflows/release-docs-ci.yml
+++ b/.github/workflows/release-docs-ci.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -135,7 +135,7 @@ jobs:
           coverage: none
 
       - name: Install task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v3
         with:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Half of **G26** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md). Companion PR on openemr/openemr-devops handles the other six workflows in the release path.

## Summary

Bumps \`arduino/setup-task\` from \`v2\` to \`v3\` in the two workflows that install \`task\`:
- \`.github/workflows/release-docs.yml\`
- \`.github/workflows/release-docs-ci.yml\`

## Rationale

- **Node 24 native.** v2 targets Node.js 20 which is deprecated and force-run on Node 24 (see the \`Node.js 20 is deprecated\` warning surfaced in every run); v3 is the Node 24 native release.
- **No rate-limit exposure on this repo.** Both usages here already pass \`repo-token: \${{ secrets.GITHUB_TOKEN }}\`, so the anonymous-API-rate-limit failure that hit openemr-devops's release-announcements workflow on the v8_2_0 tag-push cascade (G26's originating incident) doesn't affect either of these workflows. Bumping to v3 is still worth doing for the Node runtime alignment.

## Supersedes #165

Dependabot's [#165](https://github.com/openemr/website-openemr/pull/165) proposed the same 2 → 3 version bump on the same two files. This PR carries the same version-bump content in a single commit with a commit message that references the G26 incident. Close #165 as superseded once this lands.

## Test plan

- [ ] CI (actionlint, phpunit, hugo build)
- [ ] After merge: verify next release-docs dispatch runs \`Install task\` step on Node 24 (no \"Node 20 deprecated\" warning)