### PR TITLE
feat(dispatch): openemr-tag event now carries prev_release

### DIFF
--- a/tools/release-docs/contracts/dispatch.schema.json
+++ b/tools/release-docs/contracts/dispatch.schema.json
@@ -98,11 +98,12 @@
                         "data": {
                             "type": "object",
                             "additionalProperties": false,
-                            "required": ["tag", "branch", "version"],
+                            "required": ["tag", "branch", "version", "prev_release"],
                             "properties": {
                                 "tag": { "$ref": "#/$defs/tag" },
                                 "branch": { "$ref": "#/$defs/branch" },
-                                "version": { "$ref": "#/$defs/version" }
+                                "version": { "$ref": "#/$defs/version" },
+                                "prev_release": { "$ref": "#/$defs/version" }
                             }
                         }
                     }

--- a/tools/release-docs/contracts/inputs-to-envelope.jq
+++ b/tools/release-docs/contracts/inputs-to-envelope.jq
@@ -18,7 +18,7 @@
   dispatched_at: $ts,
   data: (
     if   .event == "openemr-tag"
-    then {tag: .tag, branch: .branch, version: .version}
+    then {tag: .tag, branch: .branch, version: .version, prev_release: .prev_release}
     else {branch: .branch, version: .version, prev_release: .prev_release}
     end
   ),

--- a/tools/release-docs/tests/fixtures/dispatch/invalid-openemr-tag-missing-prev-release.json
+++ b/tools/release-docs/tests/fixtures/dispatch/invalid-openemr-tag-missing-prev-release.json
@@ -7,7 +7,6 @@
     "data": {
         "tag": "v8_1_0",
         "branch": "rel-810",
-        "version": "8.1.0",
-        "prev_release": "8.0.0"
+        "version": "8.1.0"
     }
 }

--- a/tools/release-docs/tests/fixtures/dispatch/invalid-openemr-tag-missing-prev-release.json
+++ b/tools/release-docs/tests/fixtures/dispatch/invalid-openemr-tag-missing-prev-release.json
@@ -5,8 +5,8 @@
     "actor": "openemr-release-bot[bot]",
     "dispatched_at": "2026-05-01T10:00:00Z",
     "data": {
-        "tag": "v8_1_0",
-        "branch": "rel-810",
-        "version": "8.1.0"
+        "tag": "v8_2_0",
+        "branch": "rel-820",
+        "version": "8.2.0"
     }
 }

--- a/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
+++ b/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
@@ -5,9 +5,9 @@
     "actor": "openemr-release-bot[bot]",
     "dispatched_at": "2026-05-01T10:00:00Z",
     "data": {
-        "tag": "v8_1_0-test.abcdef0",
+        "tag": "v8_2_0-test.abcdef0",
         "branch": "rel-test",
-        "version": "8.1.0",
+        "version": "8.2.0",
         "prev_release": "8.0.0"
     }
 }

--- a/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
+++ b/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag-test.json
@@ -7,6 +7,7 @@
     "data": {
         "tag": "v8_1_0-test.abcdef0",
         "branch": "rel-test",
-        "version": "8.1.0"
+        "version": "8.1.0",
+        "prev_release": "8.0.0"
     }
 }

--- a/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag.json
+++ b/tools/release-docs/tests/fixtures/dispatch/valid-openemr-tag.json
@@ -5,9 +5,9 @@
     "actor": "openemr-release-bot[bot]",
     "dispatched_at": "2026-05-01T10:00:00Z",
     "data": {
-        "tag": "v8_1_0",
-        "branch": "rel-810",
-        "version": "8.1.0",
+        "tag": "v8_2_0",
+        "branch": "rel-820",
+        "version": "8.2.0",
         "prev_release": "8.0.0"
     }
 }


### PR DESCRIPTION
Website-openemr third of **G20** in [`openemr/openemr:docs/release-mechanism-gaps.md`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md). Turns out to be a three-repo change (was originally scoped as two repos; the openemr-devops canonical schema surfaced as a third when the vendored-contract drift check flagged it on the openemr companion):

- **[openemr/openemr-devops#855](https://github.com/openemr/openemr-devops/pull/855)** — canonical dispatch schema (openemr-devops's `tools/release/contracts/dispatch.schema.json`) adds `prev_release` to `tagData`.
- **This PR** — website envelope schema + jq + fixtures accept `prev_release`.
- **[openemr/openemr#12887](https://github.com/openemr/openemr/pull/12887)** — vendored copy of the canonical schema (in openemr) + emitter + workflow step + tests + fixtures.

## Order-of-merge

This PR and #855 both need to land before #12887 (either order between themselves). #12887's vendored-contract drift check requires #855 merged; the emitter's payload validation requires this PR merged.

## Problem

`release-docs.yml` gates the "Generate acknowledgements" and "Generate release notes" steps on `if: steps.payload.outputs.prev_release != ''`. On the 8.2.0 shipping path the final `openemr-tag` dispatch fired with an empty `prev_release`, both gated steps SKIPPED, and the release-docs PR merged without the acknowledgements or release-notes markdown files. Recovery required manually re-firing an `openemr-rel-update` (see #181) because the `openemr-tag` event schema's `additionalProperties: false` actively strips `prev_release` at the envelope layer — so even a manual `workflow_dispatch` supplying `prev_release=8.0.0` fell through to empty at payload-output time.

Root cause is a coordinated three-place bug across three repos (schema + jq + emitter). This PR fixes the two website-openemr places; #855 fixes the canonical devops copy; #12887 wires the openemr/openemr emitter + updates its vendored copy.

## Changes

1. `tools/release-docs/contracts/dispatch.schema.json` — openemr-tag event's `data` block adds `prev_release` to `properties` + `required`. Type is the shared `#/$defs/version` used by every other version-string field.
2. `tools/release-docs/contracts/inputs-to-envelope.jq` — openemr-tag branch of the event switch now includes `prev_release: .prev_release`. Was previously the only branch that omitted it.
3. Fixtures:
   - `valid-openemr-tag.json` — adds `"prev_release": "8.0.0"` and bumps `8.1.0 → 8.2.0`, `v8_1_0 → v8_2_0`, `rel-810 → rel-820`. 8.1.0 was cut as a prerelease and skipped -- never publicly released; using it as the canonical example implied a shipped 8.1.0 existed. 8.2.0 is a real released version. `prev_release=8.0.0` is the actual previous shipped release per `data/releases.json`'s FINAL entries.
   - `valid-openemr-tag-test.json` — same version bump + `prev_release` (test-mode dispatches also carry the field).
   - NEW: `invalid-openemr-tag-missing-prev-release.json` — tests that the required-field rule fires when `prev_release` is omitted. Mirrors the existing `invalid-*-missing-*.json` pattern.
4. `payload-outputs.jq` already reads `.data.prev_release // ""` with a safe-default fallback — no change needed. The `// ""` fallback becomes a residual safety net now that the schema guarantees presence.

## Test plan

- [ ] CI: `phpunit` covers `DispatchSchemaTest` which glob-discovers `valid-*.json` (all pass) and `invalid-*.json` (all fail as expected).
- [ ] After all three companion PRs land, verify the next release's `openemr-tag` dispatch triggers acknowledgements + release-notes generation on the FINAL cut without needing a recovery dispatch.