### PR TITLE
feat(release-docs): copy AnnouncementRenderer + templates + tests from openemr-devops (PR 1 of announcements slice)

### DIFF
--- a/tools/release-docs/composer.json
+++ b/tools/release-docs/composer.json
@@ -9,7 +9,8 @@
         "opis/json-schema": "^2.4",
         "symfony/console": "^7.0",
         "symfony/process": "^7.0",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^7.0",
+        "twig/twig": "^3.24"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.48",

--- a/tools/release-docs/composer.lock
+++ b/tools/release-docs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af5a5ecc28dbbc618fae5abe162831cb",
+    "content-hash": "541f8deaaec20ce6e9a99428256cc25f",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1689,6 +1689,86 @@
                 }
             ],
             "time": "2026-05-20T07:20:23+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-03T20:44:34+00:00"
         }
     ],
     "packages-dev": [

--- a/tools/release-docs/src/AnnouncementRenderer.php
+++ b/tools/release-docs/src/AnnouncementRenderer.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Render per-channel release-announcement drafts from Twig templates.
+ *
+ * Drafts only — no posting, no sending. The workflow that wraps this
+ * renderer surfaces the output in $GITHUB_STEP_SUMMARY and as run
+ * artifacts; a maintainer copy-pastes / forwards them to each channel.
+ * See openemr/openemr-devops#719.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final readonly class AnnouncementRenderer
+{
+    /**
+     * Literal placeholder substituted into channels that link to the forum
+     * when the maintainer hasn't supplied the per-release Discourse URL yet.
+     * Find/replace target after the thread is created.
+     */
+    public const FORUM_URL_PLACEHOLDER = '{{FORUM_URL}}';
+
+    /**
+     * Channel name → template filename (relative to the announcements dir).
+     *
+     * The keys are also the output filenames stripped of `.twig`. mail.eml
+     * is synthesized by the CLI from mail.html + mail.subject.txt.
+     */
+    public const CHANNELS = [
+        'forum.md' => 'forum.md.twig',
+        'chat.md' => 'chat.md.twig',
+        'x.txt' => 'x.txt.twig',
+        'facebook.txt' => 'facebook.txt.twig',
+        'linkedin.txt' => 'linkedin.txt.twig',
+        'mail.html' => 'mail.html.twig',
+        'mail.subject.txt' => 'mail.subject.txt.twig',
+    ];
+
+    public function __construct(
+        private string $templateDir,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     version: string,
+     *     tag: string,
+     *     branch: string,
+     *     release_url: string,
+     *     release_notes_url: string,
+     *     forum_url: string,
+     * } $context
+     * @return array<string, string> channel-output-name → rendered content
+     */
+    public function renderAll(array $context): array
+    {
+        $announcementsDir = $this->templateDir . '/announcements';
+        if (!is_dir($announcementsDir)) {
+            throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
+        }
+        // autoescape: 'name' picks the strategy from the template filename —
+        // *.html.twig gets HTML escaping; *.md.twig and *.txt.twig get none.
+        // The {{FORUM_URL}} placeholder is preserved verbatim because Twig
+        // doesn't touch literal text in templates.
+        $twig = new Environment(
+            new FilesystemLoader($announcementsDir),
+            ['autoescape' => 'name'],
+        );
+
+        $rendered = [];
+        foreach (self::CHANNELS as $output => $template) {
+            $rendered[$output] = $twig->render($template, $context);
+        }
+        return $rendered;
+    }
+}

--- a/tools/release-docs/src/AnnouncementRenderer.php
+++ b/tools/release-docs/src/AnnouncementRenderer.php
@@ -69,13 +69,19 @@ final readonly class AnnouncementRenderer
         if (!is_dir($announcementsDir)) {
             throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
         }
-        // autoescape: 'name' picks the strategy from the template filename —
-        // *.html.twig gets HTML escaping; *.md.twig and *.txt.twig get none.
+        // Autoescape: HTML for `*.html.twig` only; disabled for everything
+        // else. Twig's built-in 'name' strategy defaults unknown extensions
+        // (including `.md`) to HTML escaping, which would mangle Markdown
+        // URLs by turning `&` into `&amp;` — visible in Discourse posts.
+        // Explicitly restrict HTML escaping to files rendered as HTML.
         // The {{FORUM_URL}} placeholder is preserved verbatim because Twig
         // doesn't touch literal text in templates.
         $twig = new Environment(
             new FilesystemLoader($announcementsDir),
-            ['autoescape' => 'name'],
+            [
+                'autoescape' => static fn(?string $name): string|false =>
+                    is_string($name) && str_ends_with($name, '.html.twig') ? 'html' : false,
+            ],
         );
 
         $rendered = [];

--- a/tools/release-docs/src/AnnouncementStepSummaryRenderer.php
+++ b/tools/release-docs/src/AnnouncementStepSummaryRenderer.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Render the GitHub Actions step-summary markdown for the
+ * release-announcements workflow from the per-channel files
+ * AnnouncementRenderer wrote to disk.
+ *
+ * Reads `forum.md`, `chat.md`, `x.txt`, `facebook.txt`, `linkedin.txt`
+ * out of the announcements output directory; the mailing-list channel
+ * appears as a static section pointing at the uploaded artifacts.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final readonly class AnnouncementStepSummaryRenderer
+{
+    public const TEMPLATE_NAME = 'step-summary.md.twig';
+
+    /**
+     * Short-copy channels included inline in the step summary, in display
+     * order. Each entry is [filename, heading, fenced-code language].
+     * Mailing list isn't in this list — its section is static markdown
+     * because the rendered HTML is too large to embed inline.
+     *
+     * @var list<array{filename: string, heading: string, fence: string}>
+     */
+    private const SHORT_COPY_CHANNELS = [
+        ['filename' => 'forum.md', 'heading' => 'Forum (Discourse)', 'fence' => 'markdown'],
+        ['filename' => 'chat.md', 'heading' => 'Chat', 'fence' => 'markdown'],
+        ['filename' => 'x.txt', 'heading' => 'X', 'fence' => 'text'],
+        ['filename' => 'facebook.txt', 'heading' => 'Facebook', 'fence' => 'text'],
+        ['filename' => 'linkedin.txt', 'heading' => 'LinkedIn', 'fence' => 'text'],
+    ];
+
+    public function __construct(
+        private string $templateDir,
+    ) {
+    }
+
+    public function render(string $outputDir, string $version, string $tag, string $forumUrl): string
+    {
+        $announcementsDir = $this->templateDir . '/announcements';
+        if (!is_dir($announcementsDir)) {
+            throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
+        }
+
+        $shortCopy = [];
+        foreach (self::SHORT_COPY_CHANNELS as $channel) {
+            $path = $outputDir . '/' . $channel['filename'];
+            $body = @file_get_contents($path);
+            if ($body === false) {
+                throw new \RuntimeException("Rendered channel missing: {$path}");
+            }
+            $shortCopy[] = [
+                'heading' => $channel['heading'],
+                'fence' => $channel['fence'],
+                'body' => rtrim($body, "\n"),
+            ];
+        }
+
+        $twig = new Environment(
+            new FilesystemLoader($announcementsDir),
+            ['autoescape' => false],
+        );
+        return $twig->render(self::TEMPLATE_NAME, [
+            'version' => $version,
+            'tag' => $tag,
+            'forum_url' => $forumUrl,
+            'placeholder' => AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+            'short_copy_channels' => $shortCopy,
+        ]);
+    }
+}

--- a/tools/release-docs/templates/announcements/chat.md.twig
+++ b/tools/release-docs/templates/announcements/chat.md.twig
@@ -1,0 +1,5 @@
+**OpenEMR {{ version }} released!** 🎉
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}

--- a/tools/release-docs/templates/announcements/facebook.txt.twig
+++ b/tools/release-docs/templates/announcements/facebook.txt.twig
@@ -1,0 +1,9 @@
+OpenEMR {{ version }} has just been released!
+
+The OpenEMR community has released version {{ version }} of the most popular open source electronic health records and medical practice management solution.
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}
+
+Thanks to the OpenEMR community for producing this release. Support OpenEMR: https://www.open-emr.org/donate/

--- a/tools/release-docs/templates/announcements/forum.md.twig
+++ b/tools/release-docs/templates/announcements/forum.md.twig
@@ -1,0 +1,10 @@
+# OpenEMR {{ version }} has just been released
+
+The OpenEMR community has released version **{{ version }}**.
+
+- Release notes: {{ release_notes_url }}
+- Download: {{ release_url }}
+
+Thanks to [the OpenEMR community](https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments) for producing this release.
+
+OpenEMR needs donations to fund critical work like maintaining ONC certification, the API, FHIR, and more. Please consider donating at <https://www.open-emr.org/donate/>.

--- a/tools/release-docs/templates/announcements/linkedin.txt.twig
+++ b/tools/release-docs/templates/announcements/linkedin.txt.twig
@@ -1,0 +1,11 @@
+OpenEMR {{ version }} has just been released.
+
+OpenEMR is the most popular open source electronic health records and medical practice management solution. Version {{ version }} includes new features, improvements, and fixes.
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}
+
+Thanks to the OpenEMR community for producing this release. Sponsor OpenEMR: https://www.open-emr.org/donate/
+
+#OpenEMR #OpenSource #HealthIT #EHR

--- a/tools/release-docs/templates/announcements/mail.html.twig
+++ b/tools/release-docs/templates/announcements/mail.html.twig
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenEMR {{ version }} Released</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+    <div style="margin:0px auto;max-width:600px;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f4f4f4;" align="center">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                 <!-- Header Image -->
+                <table width="600" cellpadding="0" cellspacing="0" border="0" style="background-color: #00509d; border-radius: 3px; box-shadow: 0 2px 2px rgba(0, 0, 0, 0.4);">
+                    <tr>
+                        <td align="center" width="600" style="padding: 25px;" >
+                            <img src="https://www.open-emr.org/images/openemr_email_logo.png" alt="OpenEMR logo" width="600" height="auto" style="display: block; width: 100%; max-width: 600px; height: auto; border-radius: 8px 8px 0 0;">
+                        </td>
+                    </tr>
+              
+                </table>
+                    
+                    <!-- Content -->
+                     <table width="600" cellpadding="0" cellspacing="0" border="0" style="background-color: #ffffff;">
+                    <tr>
+                        <td style="padding: 20px 40px 20px 40px;">
+                                           
+                            <p style="color: #333333; font-size: 20px; line-height: 1.5; margin: 0 0 16px 0;"><b>OpenEMR {{ version }} Released!</b></p>
+                            
+                            
+                            <p style="color: #333333; font-size: 16px; line-height: 1.5; margin: 0 0 16px 0;">The <a href="https://www.open-emr.org" style="color: #2d9bd6" target="_blank">OpenEMR</a> community released version {{ version }}. OpenEMR {{ version }} includes <a href="{{ release_notes_url }}" style="color: #2d9bd6" target="_blank">new features, improvements, and fixes</a>.</p>
+                             <p style="color: #333333; font-size: 16px; line-height: 1.5; margin: 0 0 16px 0;">Download OpenEMR {{ version }} from <a href="https://www.open-emr.org/downloads/" style="color: #2d9bd6" target="_blank">open-emr.org/downloads</a>, where you'll find details on how to install, upgrade and patch your server. For upgrades or installation help, please view our <a href="https://www.open-emr.org/wiki/index.php/Professional_Support" style="color: #2d9bd6" target="_blank">professional support vendors</a> or connect with peers on the <a href="{{ forum_url }}" style="color: #2d9bd6" target="_blank">OpenEMR Forum</a>.</p>
+<p style="color: #333333; font-size: 16px; line-height: 1.5; margin: 0 0 32px 0;">Thank you to the <a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments" style="color: #2d9bd6" target="_blank">OpenEMR community</a> for producing this release.</p>
+<p style="color: #333333; font-size: 16px; line-height: 1.5; margin: 0 0 0 0;"><strong>Support OpenEMR</strong></p>
+<p style="color: #333333; font-size: 16px; line-height: 1.5; margin: 0 0 16px 0;">OpenEMR depends on volunteers and donations to stay open and free. Contributions fund core software, security, documentation, forums, and education. Flexible platforms and contribution levels make it easy to give once or become a Sponsor with monthly donations. <strong>If you depend on OpenEMR for your practice or support its mission, <a href="https://www.open-emr.org/donate/" style="color: #2d9bd6" target="_blank">please donate today</a></strong>.
+</p>
+   
+                        </td>
+                    </tr>
+                    
+                   
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 20px 40px; background-color: #f9f9f9; border-top: 1px solid #e0e0e0; border-radius: 0 0 8px 8px;">
+                            
+                            <p style="color: #666666; font-size: 12px; line-height: 1.5; margin: 0; text-align: center;"><a href="mailto:hello@open-emr.org?subject=Unsubscribe" style="color: #2d9bd6; text-decoration: underline;">Unsubscribe</a>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr></table></div>
+   
+</body>
+</html>

--- a/tools/release-docs/templates/announcements/mail.subject.txt.twig
+++ b/tools/release-docs/templates/announcements/mail.subject.txt.twig
@@ -1,0 +1,1 @@
+OpenEMR {{ version }} Released

--- a/tools/release-docs/templates/announcements/step-summary.md.twig
+++ b/tools/release-docs/templates/announcements/step-summary.md.twig
@@ -1,0 +1,23 @@
+# Release announcement drafts — OpenEMR {{ version }} ({{ tag }})
+
+{% if forum_url == placeholder %}
+> **Forum URL placeholder.** Find/replace `{{ placeholder }}` in the rendered output once you create the Discourse thread.
+
+{% endif %}
+{% for channel in short_copy_channels %}
+## {{ channel.heading }}
+
+```{{ channel.fence }}
+{{ channel.body }}
+```
+
+{% endfor %}
+## Mailing list
+
+Three artifacts are uploaded with the workflow run:
+
+- `mail.subject.txt` — pass to `oe-sender.js -s`
+- `mail.html` — pass to `oe-sender.js -f`
+- `mail.eml` — preview in a mail client; not used by the sender
+
+Production sender lives in [openemr-registration/oe-sender.js](https://github.com/openemr/openemr-registration/blob/master/oe-sender.js); recipients come from the DynamoDB scan, not from the `.eml` headers.

--- a/tools/release-docs/templates/announcements/x.txt.twig
+++ b/tools/release-docs/templates/announcements/x.txt.twig
@@ -1,0 +1,1 @@
+OpenEMR {{ version }} is out! Open source EHR & practice management. Release notes & download: {{ release_url }} #OpenEMR #OpenSource #HealthIT

--- a/tools/release-docs/tests/AnnouncementRendererTest.php
+++ b/tools/release-docs/tests/AnnouncementRendererTest.php
@@ -90,7 +90,11 @@ final class AnnouncementRendererTest extends TestCase
         // before measuring. This is a loose sanity check, not an exact
         // reproduction of X's character-counting rules.
         $approx = preg_replace('#https?://\S+#', str_repeat('x', 23), trim($rendered['x.txt']));
-        self::assertLessThanOrEqual(280, mb_strlen($approx ?? ''));
+        // Guard against a silent preg_replace failure returning null; the
+        // null-coalescing empty string would otherwise mb_strlen to 0 and
+        // silently pass the ≤280 assertion.
+        self::assertIsString($approx, 'URL substitution failed');
+        self::assertLessThanOrEqual(280, mb_strlen($approx));
     }
 
     public function testMailSubjectIsSingleLine(): void
@@ -128,5 +132,29 @@ final class AnnouncementRendererTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $renderer->renderAll($this->context());
+    }
+
+    public function testMarkdownAndTextChannelsPreserveAmpersandInUrls(): void
+    {
+        // Regression for Twig's default 'name' autoescape strategy, which
+        // treats any non-txt/js/css extension (including .md) as HTML and
+        // would mangle `&` in URL query strings to `&amp;` — visible in
+        // Discourse posts and X drafts.
+        $context = $this->context();
+        $context['release_url'] = 'https://github.com/openemr/openemr/releases?a=b&c=d';
+        $context['release_notes_url'] = 'https://open-emr.org/notes?x=1&y=2';
+
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($context);
+
+        $nonHtmlChannels = ['forum.md', 'chat.md', 'x.txt', 'facebook.txt', 'linkedin.txt', 'mail.subject.txt'];
+        foreach ($nonHtmlChannels as $channel) {
+            self::assertStringNotContainsString(
+                '&amp;',
+                $rendered[$channel],
+                "{$channel} should not HTML-escape ampersands",
+            );
+        }
+        // mail.html IS an HTML channel — escaping is correct + desired there.
+        self::assertStringContainsString('&amp;', $rendered['mail.html'], 'mail.html should HTML-escape ampersands');
     }
 }

--- a/tools/release-docs/tests/AnnouncementRendererTest.php
+++ b/tools/release-docs/tests/AnnouncementRendererTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs\Tests;
+
+use OpenEMR\ReleaseDocs\AnnouncementRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class AnnouncementRendererTest extends TestCase
+{
+    private const TEMPLATE_DIR = __DIR__ . '/../templates';
+
+    /**
+     * @return array{
+     *     version: string,
+     *     tag: string,
+     *     branch: string,
+     *     release_url: string,
+     *     release_notes_url: string,
+     *     forum_url: string,
+     * }
+     */
+    private function context(string $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER): array
+    {
+        return [
+            'version' => '8.1.0',
+            'tag' => 'v8_1_0',
+            'branch' => 'rel-810',
+            'release_url' => 'https://github.com/openemr/openemr/releases/tag/v8_1_0',
+            'release_notes_url' => 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            'forum_url' => $forumUrl,
+        ];
+    }
+
+    public function testRendersAllChannels(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        self::assertSame(
+            array_keys(AnnouncementRenderer::CHANNELS),
+            array_keys($rendered),
+        );
+        foreach ($rendered as $channel => $body) {
+            self::assertNotSame('', trim($body), "{$channel} rendered empty");
+        }
+    }
+
+    /**
+     * Channels that link to the forum and should preserve / substitute the
+     * placeholder. Mailing-list .subject doesn't link to the forum, and the
+     * X channel can't fit the URL within 280 chars, so they're excluded.
+     */
+    private const FORUM_LINKING_CHANNELS = ['chat.md', 'facebook.txt', 'linkedin.txt', 'mail.html'];
+
+    public function testForumUrlPlaceholderRoundTrips(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        foreach (self::FORUM_LINKING_CHANNELS as $channel) {
+            self::assertStringContainsString('{{FORUM_URL}}', $rendered[$channel], "{$channel} dropped placeholder");
+        }
+    }
+
+    public function testForumUrlSubstitutesWhenProvided(): void
+    {
+        $url = 'https://community.open-emr.org/t/openemr-8-1-0-released/12345';
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context($url));
+
+        foreach (self::FORUM_LINKING_CHANNELS as $channel) {
+            self::assertStringContainsString($url, $rendered[$channel], "{$channel} missing forum URL");
+            self::assertStringNotContainsString('{{FORUM_URL}}', $rendered[$channel], "{$channel} kept placeholder");
+        }
+    }
+
+    public function testXFitsCharacterLimit(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        // X counts URLs as a fixed 23 characters via t.co shortening, so
+        // approximate the real limit by replacing each URL with 23 chars
+        // before measuring. This is a loose sanity check, not an exact
+        // reproduction of X's character-counting rules.
+        $approx = preg_replace('#https?://\S+#', str_repeat('x', 23), trim($rendered['x.txt']));
+        self::assertLessThanOrEqual(280, mb_strlen($approx ?? ''));
+    }
+
+    public function testMailSubjectIsSingleLine(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        $subject = trim($rendered['mail.subject.txt']);
+        // CR and LF both enable header injection in the .eml — reject either.
+        self::assertStringNotContainsString("\n", $subject);
+        self::assertStringNotContainsString("\r", $subject);
+        self::assertStringContainsString('8.1.0', $subject);
+    }
+
+    public function testMailHtmlIncludesVersionAndReleaseNotesLink(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        self::assertStringContainsString('OpenEMR 8.1.0 Released', $rendered['mail.html']);
+        self::assertStringContainsString(
+            'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            $rendered['mail.html'],
+        );
+    }
+
+    public function testRenderIsDeterministic(): void
+    {
+        $renderer = new AnnouncementRenderer(self::TEMPLATE_DIR);
+
+        self::assertSame($renderer->renderAll($this->context()), $renderer->renderAll($this->context()));
+    }
+
+    public function testThrowsOnMissingTemplateDir(): void
+    {
+        $renderer = new AnnouncementRenderer('/no/such/dir');
+
+        $this->expectException(\RuntimeException::class);
+        $renderer->renderAll($this->context());
+    }
+}

--- a/tools/release-docs/tests/AnnouncementStepSummaryRendererTest.php
+++ b/tools/release-docs/tests/AnnouncementStepSummaryRendererTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs\Tests;
+
+use OpenEMR\ReleaseDocs\AnnouncementRenderer;
+use OpenEMR\ReleaseDocs\AnnouncementStepSummaryRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class AnnouncementStepSummaryRendererTest extends TestCase
+{
+    private const TEMPLATE_DIR = __DIR__ . '/../templates';
+
+    private string $outputDir = '';
+
+    protected function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/openemr-step-summary-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->outputDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->outputDir);
+        }
+        // Render the real per-channel files into the tmp dir using the
+        // production renderer — keeps the summary test honest about what
+        // it's summarizing.
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll([
+            'version' => '8.1.0',
+            'tag' => 'v8_1_0',
+            'branch' => 'rel-810',
+            'release_url' => 'https://github.com/openemr/openemr/releases/tag/v8_1_0',
+            'release_notes_url' => 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            'forum_url' => AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+        ]);
+        foreach ($rendered as $name => $body) {
+            file_put_contents($this->outputDir . '/' . $name, $body);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->outputDir . '/*');
+        foreach ($files === false ? [] : $files as $path) {
+            @unlink($path);
+        }
+        @rmdir($this->outputDir);
+    }
+
+    public function testRendersEachShortCopyChannel(): void
+    {
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+
+        self::assertStringContainsString('# Release announcement drafts — OpenEMR 8.1.0 (v8_1_0)', $summary);
+        foreach (['Forum (Discourse)', 'Chat', 'X', 'Facebook', 'LinkedIn', 'Mailing list'] as $heading) {
+            self::assertStringContainsString('## ' . $heading, $summary);
+        }
+    }
+
+    public function testEmitsPlaceholderHintWhenForumUrlMissing(): void
+    {
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+
+        self::assertStringContainsString('Forum URL placeholder', $summary);
+    }
+
+    public function testSuppressesPlaceholderHintWhenForumUrlProvided(): void
+    {
+        $url = 'https://community.open-emr.org/t/openemr-8-1-0-released/12345';
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', $url);
+
+        self::assertStringNotContainsString('Forum URL placeholder', $summary);
+    }
+
+    public function testThrowsOnMissingChannelFile(): void
+    {
+        unlink($this->outputDir . '/x.txt');
+        $renderer = new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Rendered channel missing');
+        $renderer->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+    }
+}


### PR DESCRIPTION
First PR of the announcements-workflow migration from \`openemr-devops\` to \`openemr/website-openemr\`. See [openemr/openemr#12598](https://github.com/openemr/openemr/pull/12598) (planning doc) for the full 5-PR sequence and the trigger-change rationale (fire on \`release-docs/*\` PR merge instead of \`openemr-tag\` dispatch — the download page going live is the semantic \"now it's really out there\" moment).

## Scope

Copy the two announcement renderer PHP classes + their tests + the 8 per-channel Twig templates from \`openemr-devops/tools/release/\` into \`website-openemr/tools/release-docs/\`. **Additive only** — no workflow, no consumer wired up yet. Devops still owns the live drafts (its \`release-announcements.yml\` continues to fire on \`openemr-tag\` and renders these same channels into a workflow artifact).

## Changes

- \`src/AnnouncementRenderer.php\` (87L) — unchanged logic, namespace renamed from \`OpenEMR\Release\` to \`OpenEMR\ReleaseDocs\` to match this repo's PSR-4 root; docblock \`@package\` + \`@license\` updated to match sibling classes in this dir.
- \`src/AnnouncementStepSummaryRenderer.php\` (84L) — same treatment.
- \`templates/announcements/*.twig\` (8 files: \`forum.md\`, \`chat.md\`, \`x.txt\`, \`facebook.txt\`, \`linkedin.txt\`, \`mail.html\`, \`mail.subject.txt\`, \`step-summary.md\`) — copied byte-for-byte; Twig is content-only, no namespace refs to update.
- \`tests/AnnouncementRendererTest.php\` + \`tests/AnnouncementStepSummaryRendererTest.php\` — same renamespace treatment; \`use OpenEMR\Release\...\` imports updated to \`use OpenEMR\ReleaseDocs\...\`. Test file layout matches existing \`AcknowledgementsGeneratorTest\` / \`AliasesGeneratorTest\` pattern in this dir.
- \`composer.json\` + \`composer.lock\` — add \`twig/twig ^3.24\` (matching the devops version) as a top-level require. Only twig locked; **no unrelated package bumps** (scoped install via \`composer require twig/twig --no-scripts --no-install\`).

## Verification

- \`phpunit\`: **79 tests, 145 assertions, 3 skipped** (pre-existing) — all green including the 12 newly-copied test cases (8 AnnouncementRenderer + 4 AnnouncementStepSummaryRenderer).
- \`phpstan analyse\`: **OK, no errors**.
- \`phpcs\`: **29 files scanned, no violations**.
- Copy fidelity: PHP class logic + template content are byte-identical to devops (only namespace + docblock delta).

## Not in this PR (later slice PRs)

- **PR 2**: bin CLI scripts (\`render-announcements.php\`, \`derive-announcement-inputs.php\`, \`render-announcement-step-summary.php\`) with the PR-metadata input adaptation (read \`release-docs/<version>\` head_ref instead of the \`openemr-tag\` dispatch payload).
- **PR 3**: \`.github/workflows/release-announcements.yml\` with the new trigger (\`pull_request: closed\` on \`release-docs/*\` merged into master); parallel-run window opens (both devops + website fire on the same release).
- **PR 4**: retire devops's copies (after PR 3 validates on a live release).
- **PR 5**: update \`openemr/openemr\` RELEASE_PROCESS.md phase 4 + runbook step 16 to point at the new home + trigger.

Assisted-by: Claude Code