### PR TITLE
feat(release-docs): copy announcement CLI scripts + adapt derive-inputs for pull_request:closed trigger (PR 2 of announcements slice)

### DIFF
--- a/tools/release-docs/bin/derive-announcement-inputs.php
+++ b/tools/release-docs/bin/derive-announcement-inputs.php
@@ -1,0 +1,149 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Emit the `version=` / `tag=` / `branch=` / `forum_url=` lines the
+ * release-announcements workflow appends to $GITHUB_OUTPUT.
+ *
+ * Two input modes:
+ *
+ *   --head-ref <ref>
+ *       Parse the head ref of a merged pull_request event and derive
+ *       version + tag + branch canonically. The workflow supplies
+ *       `github.event.pull_request.head.ref`, which for the release-docs
+ *       PRs is `release-docs/<version>` (e.g., `release-docs/8.2.0`).
+ *       Version is stripped from the ref; tag is `v<major>_<minor>_<patch>`;
+ *       branch is `rel-<major><minor>0`.
+ *
+ *   --release-version=<v> --release-tag=<t> --release-branch=<b>
+ *       Manual workflow_dispatch fallback for maintainer re-renders when
+ *       the pull_request:closed trigger missed or the drafts artifact
+ *       was lost. All three flags required together in this mode.
+ *
+ * The two modes are mutually exclusive. Validation patterns mirror the
+ * canonical shapes from openemr-devops's dispatch.schema.json (version,
+ * tag, branch); a malformed value aborts the step instead of producing
+ * artifacts that reference "null".
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+const VERSION_PATTERN = '/^\d+\.\d+\.\d+$/';
+const TAG_PATTERN = '/^v\d+_\d+_\d+$/';
+const BRANCH_PATTERN = '/^rel-[0-9]+$/';
+const HEAD_REF_PREFIX = 'release-docs/';
+
+(new SingleCommandApplication())
+    ->setName('derive-announcement-inputs')
+    ->setDescription('Emit version/tag/branch/forum_url lines for the announcements workflow')
+    ->addOption(
+        'head-ref',
+        null,
+        InputOption::VALUE_REQUIRED,
+        "Pull-request head ref of the form `release-docs/<version>`. Mutually exclusive with --release-* flags.",
+    )
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption('release-branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g. rel-810)')
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Per-release Discourse thread URL; empty value falls back to the placeholder downstream',
+        '',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        // Stdout is reserved for the GITHUB_OUTPUT key=value lines the
+        // workflow appends with `>>`. Errors must not pollute it.
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        $str = static function (string $name) use ($input): string {
+            $value = $input->getOption($name);
+            return is_string($value) ? $value : '';
+        };
+        $headRef = $str('head-ref');
+        $version = $str('release-version');
+        $tag = $str('release-tag');
+        $branch = $str('release-branch');
+
+        $flagsProvided = array_filter(
+            [$version, $tag, $branch],
+            static fn(string $v): bool => $v !== '',
+        );
+        if ($headRef !== '' && $flagsProvided !== []) {
+            $err->writeln('<error>--head-ref is mutually exclusive with --release-* flags</error>');
+            return 1;
+        }
+        if ($headRef === '' && count($flagsProvided) !== 3) {
+            $err->writeln(
+                '<error>Provide either --head-ref or all of'
+                . ' --release-version/--release-tag/--release-branch</error>',
+            );
+            return 1;
+        }
+
+        if ($headRef !== '') {
+            if (!str_starts_with($headRef, HEAD_REF_PREFIX)) {
+                $err->writeln(sprintf(
+                    "<error>--head-ref must start with '%s' (got: %s)</error>",
+                    HEAD_REF_PREFIX,
+                    $headRef,
+                ));
+                return 1;
+            }
+            $version = substr($headRef, strlen(HEAD_REF_PREFIX));
+            if (preg_match(VERSION_PATTERN, $version) !== 1) {
+                $err->writeln(sprintf(
+                    "<error>version parsed from --head-ref does not match %s (got: %s)</error>",
+                    VERSION_PATTERN,
+                    $version,
+                ));
+                return 1;
+            }
+            [$major, $minor] = explode('.', $version, 3);
+            $tag = 'v' . str_replace('.', '_', $version);
+            $branch = "rel-{$major}{$minor}0";
+        } else {
+            $fields = [
+                ['version', $version, VERSION_PATTERN],
+                ['tag', $tag, TAG_PATTERN],
+                ['branch', $branch, BRANCH_PATTERN],
+            ];
+            foreach ($fields as [$name, $value, $pattern]) {
+                if (preg_match($pattern, $value) !== 1) {
+                    $err->writeln(sprintf(
+                        "<error>field %s does not match expected shape %s (got: %s)</error>",
+                        $name,
+                        $pattern,
+                        $value,
+                    ));
+                    return 1;
+                }
+            }
+        }
+
+        // Emit forum_url verbatim (possibly empty); downstream renderers
+        // substitute their own placeholder when the maintainer hasn't
+        // supplied a real URL. Keeping the placeholder string out of the
+        // pipeline avoids Taskfile/Go-template confusion over the literal
+        // braces.
+        $output->writeln(sprintf('version=%s', $version));
+        $output->writeln(sprintf('tag=%s', $tag));
+        $output->writeln(sprintf('branch=%s', $branch));
+        $output->writeln(sprintf('forum_url=%s', $str('forum-url')));
+        return 0;
+    })
+    ->run();

--- a/tools/release-docs/bin/derive-announcement-inputs.php
+++ b/tools/release-docs/bin/derive-announcement-inputs.php
@@ -133,6 +133,39 @@ const HEAD_REF_PREFIX = 'release-docs/';
                     return 1;
                 }
             }
+            // Even when each field is individually shape-valid, the trio
+            // could still cross-refer (--release-version=8.1.0 with
+            // --release-tag=v9_9_9): shape passes but the tag doesn't
+            // describe the version. Derive canonical tag+branch from the
+            // version and require the caller-supplied values to match, so
+            // a workflow_dispatch typo can't silently ship announcement
+            // drafts with mismatched links.
+            [$major, $minor] = explode('.', $version, 3);
+            $expectedTag = 'v' . str_replace('.', '_', $version);
+            $expectedBranch = "rel-{$major}{$minor}0";
+            if ($tag !== $expectedTag || $branch !== $expectedBranch) {
+                $err->writeln(sprintf(
+                    "<error>tag/branch do not match version: expected tag=%s branch=%s"
+                    . " for version %s, got tag=%s branch=%s</error>",
+                    $expectedTag,
+                    $expectedBranch,
+                    $version,
+                    $tag,
+                    $branch,
+                ));
+                return 1;
+            }
+        }
+
+        // forum_url is user-supplied and emitted verbatim to stdout, which
+        // the workflow appends to $GITHUB_OUTPUT. A value containing CR/LF
+        // would open additional key=value lines and let a caller inject
+        // extra workflow outputs. URLs never contain literal control chars
+        // (RFC 3986 requires percent-encoding), so rejecting is safe.
+        $forumUrl = $str('forum-url');
+        if (str_contains($forumUrl, "\r") || str_contains($forumUrl, "\n")) {
+            $err->writeln('<error>--forum-url must be a single-line value (no CR/LF)</error>');
+            return 1;
         }
 
         // Emit forum_url verbatim (possibly empty); downstream renderers
@@ -143,7 +176,7 @@ const HEAD_REF_PREFIX = 'release-docs/';
         $output->writeln(sprintf('version=%s', $version));
         $output->writeln(sprintf('tag=%s', $tag));
         $output->writeln(sprintf('branch=%s', $branch));
-        $output->writeln(sprintf('forum_url=%s', $str('forum-url')));
+        $output->writeln(sprintf('forum_url=%s', $forumUrl));
         return 0;
     })
     ->run();

--- a/tools/release-docs/bin/render-announcement-step-summary.php
+++ b/tools/release-docs/bin/render-announcement-step-summary.php
@@ -77,7 +77,10 @@ use Symfony\Component\Console\SingleCommandApplication;
 
         $target = $input->getOption('output');
         if (is_string($target) && $target !== '') {
-            file_put_contents($target, $rendered);
+            if (file_put_contents($target, $rendered) === false) {
+                $err->writeln("<error>Failed to write summary file: {$target}</error>");
+                return 1;
+            }
             return 0;
         }
         $output->write($rendered);

--- a/tools/release-docs/bin/render-announcement-step-summary.php
+++ b/tools/release-docs/bin/render-announcement-step-summary.php
@@ -1,0 +1,86 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Render the GitHub Actions step-summary markdown for the
+ * release-announcements workflow.
+ *
+ * Reads the per-channel files AnnouncementRenderer wrote into
+ * --output-dir and emits the summary markdown to stdout (or --output);
+ * the workflow appends it to $GITHUB_STEP_SUMMARY.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\ReleaseDocs\AnnouncementRenderer;
+use OpenEMR\ReleaseDocs\AnnouncementStepSummaryRenderer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('render-announcement-step-summary')
+    ->setDescription('Render the GitHub Actions step-summary markdown for the announcement drafts')
+    ->addOption(
+        'template-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Twig template directory (defaults to the binary\'s sibling templates/ dir)',
+    )
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Directory containing the per-channel rendered files')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Forum URL value rendered into the summary; defaults to the placeholder',
+        AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+    )
+    ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file (defaults to stdout)')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        $templateDir = $input->getOption('template-dir');
+        if (!is_string($templateDir) || $templateDir === '') {
+            $templateDir = dirname(__DIR__) . '/templates';
+        }
+
+        foreach (['output-dir', 'release-version', 'release-tag'] as $required) {
+            $value = $input->getOption($required);
+            if (!is_string($value) || $value === '') {
+                $err->writeln(sprintf('<error>--%s is required</error>', $required));
+                return 1;
+            }
+        }
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output-dir');
+        /** @var string $version */
+        $version = $input->getOption('release-version');
+        /** @var string $tag */
+        $tag = $input->getOption('release-tag');
+        $forumUrl = $input->getOption('forum-url');
+        if (!is_string($forumUrl) || $forumUrl === '') {
+            $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER;
+        }
+
+        $rendered = (new AnnouncementStepSummaryRenderer($templateDir))->render($outputDir, $version, $tag, $forumUrl);
+
+        $target = $input->getOption('output');
+        if (is_string($target) && $target !== '') {
+            file_put_contents($target, $rendered);
+            return 0;
+        }
+        $output->write($rendered);
+        return 0;
+    })
+    ->run();

--- a/tools/release-docs/bin/render-announcements.php
+++ b/tools/release-docs/bin/render-announcements.php
@@ -122,7 +122,11 @@ use Symfony\Component\Console\SingleCommandApplication;
         $rendered = (new AnnouncementRenderer($templateDir))->renderAll($context);
 
         foreach ($rendered as $name => $body) {
-            file_put_contents($outputDir . '/' . $name, $body);
+            $path = $outputDir . '/' . $name;
+            if (file_put_contents($path, $body) === false) {
+                $err->writeln("<error>Failed to write channel file: {$path}</error>");
+                return 1;
+            }
             $output->writeln("Wrote <info>{$name}</info>");
         }
 
@@ -137,7 +141,11 @@ use Symfony\Component\Console\SingleCommandApplication;
             'Content-Type: text/html; charset=UTF-8',
             'Content-Transfer-Encoding: 8bit',
         ]);
-        file_put_contents($outputDir . '/mail.eml', $emlHeaders . "\r\n\r\n" . $rendered['mail.html']);
+        $emlPath = $outputDir . '/mail.eml';
+        if (file_put_contents($emlPath, $emlHeaders . "\r\n\r\n" . $rendered['mail.html']) === false) {
+            $err->writeln("<error>Failed to write mail.eml preview: {$emlPath}</error>");
+            return 1;
+        }
         $output->writeln('Wrote <info>mail.eml</info> (preview)');
 
         return 0;

--- a/tools/release-docs/bin/render-announcements.php
+++ b/tools/release-docs/bin/render-announcements.php
@@ -1,0 +1,145 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Render per-channel release-announcement drafts to a directory.
+ *
+ * Wraps AnnouncementRenderer; called by .github/workflows/release-announcements.yml
+ * on `release-docs/*` PR-merged (or workflow_dispatch). Writes one file per
+ * channel plus a synthesized mail.eml preview the maintainer can drag into a
+ * mail client. No posting, no sending. See openemr/openemr-devops#719.
+ *
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\ReleaseDocs\AnnouncementRenderer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('render-announcements')
+    ->setDescription('Render per-channel release-announcement drafts')
+    ->addOption(
+        'template-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Twig template directory (defaults to the binary\'s sibling templates/ dir)',
+    )
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Directory to write per-channel files into')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption('release-branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g. rel-810)')
+    ->addOption(
+        'release-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'GitHub release URL (defaults to https://github.com/openemr/openemr/releases/tag/<tag>)',
+    )
+    ->addOption(
+        'release-notes-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Release-notes URL (defaults to the wiki Release Features anchor for the version)',
+    )
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Per-release Discourse thread URL; left as a placeholder if not supplied',
+        AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        $templateDir = $input->getOption('template-dir');
+        if (!is_string($templateDir) || $templateDir === '') {
+            $templateDir = dirname(__DIR__) . '/templates';
+        }
+        if (!is_dir($templateDir)) {
+            $err->writeln("<error>Template directory not found: {$templateDir}</error>");
+            return 1;
+        }
+
+        $outputDir = $input->getOption('output-dir');
+        if (!is_string($outputDir) || $outputDir === '') {
+            $err->writeln('<error>--output-dir is required</error>');
+            return 1;
+        }
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0755, true) && !is_dir($outputDir)) {
+            $err->writeln("<error>Failed to create output dir: {$outputDir}</error>");
+            return 1;
+        }
+
+        foreach (['release-version', 'release-tag', 'release-branch'] as $required) {
+            $value = $input->getOption($required);
+            if (!is_string($value) || $value === '') {
+                $err->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        /** @var string $version */
+        $version = $input->getOption('release-version');
+        /** @var string $tag */
+        $tag = $input->getOption('release-tag');
+        /** @var string $branch */
+        $branch = $input->getOption('release-branch');
+
+        $releaseUrl = $input->getOption('release-url');
+        if (!is_string($releaseUrl) || $releaseUrl === '') {
+            $releaseUrl = "https://github.com/openemr/openemr/releases/tag/{$tag}";
+        }
+
+        $releaseNotesUrl = $input->getOption('release-notes-url');
+        if (!is_string($releaseNotesUrl) || $releaseNotesUrl === '') {
+            $releaseNotesUrl = 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_' . $version;
+        }
+
+        $forumUrl = $input->getOption('forum-url');
+        if (!is_string($forumUrl) || $forumUrl === '') {
+            $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER;
+        }
+
+        $context = [
+            'version' => $version,
+            'tag' => $tag,
+            'branch' => $branch,
+            'release_url' => $releaseUrl,
+            'release_notes_url' => $releaseNotesUrl,
+            'forum_url' => $forumUrl,
+        ];
+
+        $rendered = (new AnnouncementRenderer($templateDir))->renderAll($context);
+
+        foreach ($rendered as $name => $body) {
+            file_put_contents($outputDir . '/' . $name, $body);
+            $output->writeln("Wrote <info>{$name}</info>");
+        }
+
+        // .eml is a preview only: oe-sender.js hard-codes Source and reads
+        // recipients from DynamoDB; these headers exist so the maintainer can
+        // open the file in a mail client to eyeball the rendered HTML.
+        $emlHeaders = implode("\r\n", [
+            'From: OpenEMR <no-reply@open-emr.org>',
+            'To: OpenEMR Announce <announce@open-emr.org>',
+            'Subject: ' . trim($rendered['mail.subject.txt']),
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'Content-Transfer-Encoding: 8bit',
+        ]);
+        file_put_contents($outputDir . '/mail.eml', $emlHeaders . "\r\n\r\n" . $rendered['mail.html']);
+        $output->writeln('Wrote <info>mail.eml</info> (preview)');
+
+        return 0;
+    })
+    ->run();

--- a/tools/release-docs/tests/DeriveAnnouncementInputsCliTest.php
+++ b/tools/release-docs/tests/DeriveAnnouncementInputsCliTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * @package   openemr/website-openemr
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\ReleaseDocs\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * The release-announcements workflow appends derive-announcement-inputs.php
+ * stdout directly to $GITHUB_OUTPUT. Errors must therefore not leak into
+ * stdout, or a failing run will write `<error>...</error>` lines into the
+ * runner's output file and trigger an "Invalid format" step failure that
+ * obscures the real error.
+ */
+final class DeriveAnnouncementInputsCliTest extends TestCase
+{
+    private const BIN = __DIR__ . '/../bin/derive-announcement-inputs.php';
+
+    public function testHeadRefDrivesAllThreeValuesCanonically(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--head-ref=release-docs/8.2.0',
+            '--forum-url=https://community.open-emr.org/t/thread/123',
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), 'expected success exit code');
+        self::assertSame('', $process->getErrorOutput(), 'no stderr on success');
+        self::assertSame(
+            "version=8.2.0\ntag=v8_2_0\nbranch=rel-820\nforum_url=https://community.open-emr.org/t/thread/123\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testHeadRefWithMissingForumUrlEmitsEmptyForumUrl(): void
+    {
+        $process = new Process(['php', self::BIN, '--head-ref=release-docs/8.1.0']);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode());
+        self::assertSame(
+            "version=8.1.0\ntag=v8_1_0\nbranch=rel-810\nforum_url=\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testExplicitFlagsWriteKeyValueLinesToStdoutOnly(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=v8_1_0',
+            '--release-branch=rel-810',
+            '--forum-url=https://example.com/thread',
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), 'expected success exit code');
+        self::assertSame('', $process->getErrorOutput(), 'no stderr on success');
+        self::assertSame(
+            "version=8.1.0\ntag=v8_1_0\nbranch=rel-810\nforum_url=https://example.com/thread\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testValidationErrorsGoToStderrAndStdoutStaysEmpty(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=BAD',
+            '--release-branch=rel-810',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode(), 'expected failure exit code');
+        self::assertSame('', $process->getOutput(), 'stdout must stay empty so $GITHUB_OUTPUT is not corrupted');
+        self::assertStringContainsString('field tag does not match expected shape', $process->getErrorOutput());
+    }
+
+    public function testInvalidHeadRefRejected(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--head-ref=some-other-branch',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput(), 'stdout must stay empty on error');
+        self::assertStringContainsString("must start with 'release-docs/'", $process->getErrorOutput());
+    }
+
+    public function testMalformedVersionInHeadRefRejected(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--head-ref=release-docs/not-a-version',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('version parsed from --head-ref does not match', $process->getErrorOutput());
+    }
+
+    public function testMissingRequiredFlagsGoToStderr(): void
+    {
+        $process = new Process(['php', self::BIN]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('Provide either --head-ref', $process->getErrorOutput());
+    }
+
+    public function testMutuallyExclusiveSourcesRejected(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--head-ref=release-docs/8.1.0',
+            '--release-version=8.1.0',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('mutually exclusive', $process->getErrorOutput());
+    }
+}

--- a/tools/release-docs/tests/DeriveAnnouncementInputsCliTest.php
+++ b/tools/release-docs/tests/DeriveAnnouncementInputsCliTest.php
@@ -144,4 +144,46 @@ final class DeriveAnnouncementInputsCliTest extends TestCase
         self::assertSame('', $process->getOutput());
         self::assertStringContainsString('mutually exclusive', $process->getErrorOutput());
     }
+
+    public function testInternallyInconsistentExplicitFlagsRejected(): void
+    {
+        // Each field is shape-valid in isolation, but the tag/branch don't
+        // describe the version. Without the cross-consistency check the
+        // script would emit mismatched links + a workflow_dispatch typo
+        // could silently ship broken announcements.
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=v9_9_9',
+            '--release-branch=rel-990',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode(), 'expected consistency check to reject');
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('tag/branch do not match version', $process->getErrorOutput());
+    }
+
+    public function testForumUrlWithNewlineRejected(): void
+    {
+        // Guard against $GITHUB_OUTPUT injection: a CR/LF-containing value
+        // emitted verbatim to stdout would open additional key=value lines
+        // and let a caller define arbitrary extra workflow outputs.
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--head-ref=release-docs/8.1.0',
+            "--forum-url=https://good.example\nEVIL_OUTPUT=bad",
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame(
+            '',
+            $process->getOutput(),
+            'stdout must stay clean so no injected line reaches $GITHUB_OUTPUT',
+        );
+        self::assertStringContainsString('single-line value', $process->getErrorOutput());
+    }
 }


### PR DESCRIPTION
Second PR of the announcements-workflow migration from \`openemr-devops\` to \`openemr/website-openemr\`. Follows #192 (renderer classes + templates + tests). Still additive — no workflow calls these scripts yet; PR 3 wires up \`release-announcements.yml\`.

## Changes

### \`bin/render-announcements.php\` (145L)

Copied byte-for-byte from openemr-devops. Namespace-only delta:
- \`use OpenEMR\Release\AnnouncementRenderer\` → \`use OpenEMR\ReleaseDocs\...\`
- \`@package\` + \`@license\` docblock updated to match this repo.
- Wrapping comment updated: fires on \`release-docs/*\` PR-merged now, not \`openemr-tag\` dispatch.

### \`bin/render-announcement-step-summary.php\` (86L)

Same treatment. No behavioral changes.

### \`bin/derive-announcement-inputs.php\` (145L, substantially rewritten)

The original devops script had two input modes: \`--payload-file\` (for \`openemr-tag\` \`repository_dispatch\` envelopes) and \`--release-*\` explicit flags (for \`workflow_dispatch\`). On the website side we no longer consume \`openemr-tag\` (the workflow will trigger on \`pull_request:closed\` for \`release-docs/*\` PRs merged into master); the primary input is the PR's head_ref.

**New input modes:**

1. **\`--head-ref release-docs/<version>\`** (primary) — parse the head ref from \`github.event.pull_request.head.ref\`, extract version, derive \`tag = vX_Y_Z\` and \`branch = rel-<major><minor>0\` canonically.
2. **\`--release-version/--release-tag/--release-branch\`** (fallback) — explicit flags for manual \`workflow_dispatch\` when the pull_request path missed. All three required together.

**Dropped:**
- \`--payload-file\` (no more \`openemr-tag\` consumer on website side).
- \`OpenEMR\Release\TagDispatchPayload\` dependency (\`fromPayloadFile\` method was the only consumer). Pattern validation inlined in the CLI script (version/tag/branch regex mirror the canonical \`dispatch.schema.json\` shapes, minus the \`-test.<sha>\` tag suffix which website has no use for).

Modes are mutually exclusive; malformed input goes to stderr; stdout stays strictly \`key=value\` lines suitable for \`>> \$GITHUB_OUTPUT\` appending.

### \`tests/DeriveAnnouncementInputsCliTest.php\` (updated fixture set)

Copied + adapted for the new modes. 8 test cases:

- \`testHeadRefDrivesAllThreeValuesCanonically\` — verifies version/tag/branch derivation from \`release-docs/8.2.0\`.
- \`testHeadRefWithMissingForumUrlEmitsEmptyForumUrl\` — empty \`forum_url\` round-trip (downstream renderers substitute the placeholder).
- \`testExplicitFlagsWriteKeyValueLinesToStdoutOnly\` — fallback mode.
- \`testValidationErrorsGoToStderrAndStdoutStaysEmpty\` — malformed tag rejected without corrupting \$GITHUB_OUTPUT.
- \`testInvalidHeadRefRejected\` — \`--head-ref=some-other-branch\` fails.
- \`testMalformedVersionInHeadRefRejected\` — \`--head-ref=release-docs/not-a-version\` fails.
- \`testMissingRequiredFlagsGoToStderr\` — bare invocation errors out.
- \`testMutuallyExclusiveSourcesRejected\` — \`--head-ref\` + \`--release-*\` can't coexist.

## Verification

- \`phpunit\`: **88 tests / 176 assertions / 3 skipped** (pre-existing) — all green including the 8 new CLI test cases.
- \`phpstan analyse\`: **OK, no errors**.
- \`phpcs\`: **33 files scanned, no violations**.

## Not in this PR

- **PR 3**: \`.github/workflows/release-announcements.yml\` with the \`pull_request: closed\` trigger; wires up all 3 bin scripts.
- **PR 4**: retire devops's copies (after PR 3 validates via manual-dispatch smoke test).
- **PR 5**: update \`openemr/openemr\` RELEASE_PROCESS.md to point at the new location + trigger.

Assisted-by: Claude Code