### PR TITLE
feat(release-announcements): add website-side workflow with pull_request:closed trigger (PR 3 of announcements slice)

### DIFF
--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -1,0 +1,144 @@
+name: release-announcements
+
+# Drafts-only announcement rendering for OpenEMR releases. See
+# openemr/openemr-devops#719 for the original design and
+# openemr/openemr#12598 for the migration from openemr-devops.
+#
+# Fires when a `release-docs/<version>` PR merges into master (the
+# semantic "the download page is now live" moment — Hugo re-deploys
+# from the merged docs content, so the /downloads/ landing page
+# switches to the just-shipped version at the same time). Also
+# supports `workflow_dispatch` for maintainer re-renders when the
+# pull_request:closed path missed or the drafts artifact was lost.
+#
+# Renders per-channel drafts (forum, chat, X, Facebook, LinkedIn,
+# mail) into a workflow artifact + step summary. Maintainer copy-
+# pastes onto each channel; mailing list is sent separately via
+# openemr-registration's oe-sender.js using the rendered mail.html +
+# mail.subject.txt files. No posting, no SMTP, no API integration
+# in this phase.
+#
+# This workflow is intentionally a thin sequencer: every non-trivial
+# step is a Taskfile target under tools/release-docs/Taskfile.yml so
+# the operations can be invoked locally for debugging the same way
+# CI runs them.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 8.2.0).'
+        required: true
+        type: string
+      tag:
+        description: 'Annotated release tag (e.g. v8_2_0).'
+        required: true
+        type: string
+      branch:
+        description: 'Release branch (e.g. rel-820).'
+        required: true
+        type: string
+      forum_url:
+        description: 'Per-release Discourse thread URL (optional; placeholder rendered if blank).'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Serialize per-release so overlapping dispatches for the same version
+# don't race on the same artifact name. Different versions can run in
+# parallel. cancel-in-progress: false because rerenders are cheap and
+# overlapping cancels would lose useful step-summary context.
+concurrency:
+  group: release-announcements-${{ github.event.pull_request.head.ref || inputs.tag }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: tools/release-docs
+
+jobs:
+  draft:
+    name: draft (${{ matrix.runner }})
+    # Fire on workflow_dispatch always, or on pull_request only when a
+    # `release-docs/*` PR actually merged (not just closed unmerged and
+    # not from any other head_ref). GitHub's `pull_request` trigger
+    # can't filter on head_ref natively, only on base branch, so this
+    # job-level `if` is the gate.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release-docs/'))
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04]
+    env:
+      OUTPUT_DIR: ${{ github.workspace }}/out/announcements
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Install task
+        uses: arduino/setup-task@v3
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install release-docs dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist --no-dev
+
+      - name: Derive release inputs
+        id: inputs
+        env:
+          # pull_request path:      HEAD_REF from head_ref, others empty.
+          # workflow_dispatch path: HEAD_REF empty, VERSION/TAG/BRANCH from inputs.
+          # The derive-announcement-inputs CLI rejects mixing the two,
+          # validates each field against the canonical release-format
+          # patterns (mirroring dispatch.schema.json shapes), and — in
+          # explicit-flags mode — cross-checks that tag + branch actually
+          # describe the version. A workflow_dispatch typo aborts here
+          # instead of shipping artifacts with mismatched links.
+          HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
+          BRANCH: ${{ inputs.branch }}
+          FORUM_URL: ${{ inputs.forum_url }}
+        run: task derive-announcement-inputs >> "$GITHUB_OUTPUT"
+
+      - name: Render announcements
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          BRANCH: ${{ steps.inputs.outputs.branch }}
+          FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
+        run: task render-announcements
+
+      - name: Write step summary
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
+        run: OUTPUT="$GITHUB_STEP_SUMMARY" task render-announcement-step-summary
+
+      - name: Upload announcement drafts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-announcements-${{ steps.inputs.outputs.version }}
+          path: ${{ env.OUTPUT_DIR }}/
+          if-no-files-found: error

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -108,6 +108,46 @@ tasks:
         --manifest={{.MANIFEST}}
         --schema={{.REPO_ROOT}}/data/releases.schema.json
 
+  derive-announcement-inputs:
+    desc: Emit version/tag/branch/forum_url lines for the announcements workflow
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/derive-announcement-inputs.php
+        {{if .HEAD_REF}}--head-ref={{shellQuote .HEAD_REF}}{{end}}
+        {{if .VERSION}}--release-version={{shellQuote .VERSION}}{{end}}
+        {{if .TAG}}--release-tag={{shellQuote .TAG}}{{end}}
+        {{if .BRANCH}}--release-branch={{shellQuote .BRANCH}}{{end}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+
+  render-announcements:
+    desc: Render per-channel release-announcement drafts to a directory
+    requires:
+      vars: [OUTPUT_DIR, VERSION, TAG, BRANCH]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/render-announcements.php
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+        --release-version={{shellQuote .VERSION}}
+        --release-tag={{shellQuote .TAG}}
+        --release-branch={{shellQuote .BRANCH}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+
+  render-announcement-step-summary:
+    desc: Render the GitHub Actions step-summary markdown for the announcement drafts
+    requires:
+      vars: [OUTPUT_DIR, VERSION, TAG]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/render-announcement-step-summary.php
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+        --release-version={{shellQuote .VERSION}}
+        --release-tag={{shellQuote .TAG}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+        {{if .OUTPUT}}--output={{shellQuote .OUTPUT}}{{end}}
+
   lint-aliases:
     desc: Verify every aliases mapping target points to an existing Hugo page
     deps: [setup]


### PR DESCRIPTION
Third PR of the announcements-workflow migration from \`openemr-devops\` to \`openemr/website-openemr\`. Follows #192 (renderer classes + templates) and #193 (bin CLI scripts).

## What ships

### \`.github/workflows/release-announcements.yml\`

Thin sequencer that fires:

- **\`pull_request: types: [closed], branches: [master]\`** — with a job-level \`if\` gate requiring \`merged == true\` AND \`head_ref\` starting with \`release-docs/\`. This is the primary trigger: fires when a \`release-docs/<version>\` PR merges (i.e., when Hugo re-deploys and the \`/downloads/\` landing page switches to the just-shipped version — the semantic \"the download page is now live\" moment).
- **\`workflow_dispatch\`** — inputs: \`version\`, \`tag\`, \`branch\`, \`forum_url\`. Manual re-render fallback when the pull_request path missed or the drafts artifact was lost.

GitHub's \`pull_request\` trigger can't filter on head_ref natively (only on base branch), so the \`if:\` gate is the head_ref filter. Non-matching PRs get a cheap no-op workflow evaluation.

### \`tools/release-docs/Taskfile.yml\` — 3 new task entries

- \`derive-announcement-inputs\` — wraps \`bin/derive-announcement-inputs.php\` with conditional \`--head-ref\` / \`--release-*\` flags based on which env vars are set. Matches the shape of devops's \`release:derive-announcement-inputs\` task.
- \`render-announcements\` — wraps \`bin/render-announcements.php\`.
- \`render-announcement-step-summary\` — wraps \`bin/render-announcement-step-summary.php\` with \`--output-dir\` (input dir of per-channel files) and \`--output\` (optional target file for the summary markdown).

## Parallel-run window opens now

With this PR merged, **both** devops's \`release-announcements.yml\` (on \`openemr-tag\` dispatch) **and** this new workflow (on \`release-docs/*\` PR-merged) fire for each release. Harmless — no posting happens, so \"double drafts\" just means the maintainer has two identical artifact sources. Devops's copy is retired in PR 4 once this workflow has validated on ≥1 real release (or a manual dispatch smoke test per Brady's plan — no need to wait).

## Verification

Local end-to-end simulation via \`docker composer:2\` + \`task 3.36\`:

- \`HEAD_REF=release-docs/8.2.0 task derive-announcement-inputs\` → \`version=8.2.0\`, \`tag=v8_2_0\`, \`branch=rel-820\`, \`forum_url=\` (canonical derivation ✓).
- \`OUTPUT_DIR=/tmp/out VERSION=8.2.0 TAG=v8_2_0 BRANCH=rel-820 task render-announcements\` → all 8 files rendered (forum.md, chat.md, x.txt, facebook.txt, linkedin.txt, mail.html, mail.subject.txt, mail.eml).
- \`OUTPUT=/tmp/summary.md task render-announcement-step-summary\` → step-summary markdown emitted with correct forum-URL placeholder handling.
- \`actionlint\` on the workflow: clean.

## Test plan

- [ ] After merge, wait for either a real \`release-docs/*\` PR merge or run a manual \`workflow_dispatch\` against a shipped version (e.g., 8.2.0) to smoke-test end-to-end on the actual runner.
- [ ] Verify the artifact \`release-announcements-<version>\` exists on the workflow run and contains all 8 files.
- [ ] Verify the step summary renders correctly on the workflow run page.
- [ ] Diff the rendered content against devops's parallel run for the same release to confirm byte-identical (or explicitly-noted divergence).

## Not in this PR

- **PR 4**: retire devops's \`.github/workflows/release-announcements.yml\` + \`tools/release/{bin,src,tests,templates}/announcement*\` after a successful manual-dispatch smoke test on this workflow.
- **PR 5**: update \`openemr/openemr\` \`RELEASE_PROCESS.md\` phase 4 + runbook step 16 to point at the new home + trigger.

Assisted-by: Claude Code