### PR TITLE
sync(release-docs): forum.md.twig content update from openemr-devops

### DIFF
--- a/tools/release-docs/templates/announcements/forum.md.twig
+++ b/tools/release-docs/templates/announcements/forum.md.twig
@@ -1,10 +1,18 @@
+![OpenEMR logo|500x0](https://www.open-emr.org/images/openemr_email_logo.png)
+
 # OpenEMR {{ version }} has just been released
 
-The OpenEMR community has released version **{{ version }}**.
+The OpenEMR community has released version **{{ version }}**, which includes new features, improvements, and fixes.
 
-- Release notes: {{ release_notes_url }}
-- Download: {{ release_url }}
+- **Release notes:** {{ release_notes_url }}
+- **Download:** {{ release_url }}
+
+You'll find details on how to install, upgrade, and patch your server on the [downloads page](https://www.open-emr.org/downloads/). For help, see our [professional support vendors](https://www.open-emr.org/wiki/index.php/Professional_Support).
 
 Thanks to [the OpenEMR community](https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments) for producing this release.
 
-OpenEMR needs donations to fund critical work like maintaining ONC certification, the API, FHIR, and more. Please consider donating at <https://www.open-emr.org/donate/>.
+---
+
+**Support OpenEMR**
+
+OpenEMR depends on volunteers and donations to stay open and free. Contributions fund critical work like maintaining ONC certification, the API, FHIR, security, documentation, and the forums. **If you depend on OpenEMR for your practice or support its mission, [please donate today](https://www.open-emr.org/donate/).**


### PR DESCRIPTION
## Summary

Sync the forum announcement template from \`openemr-devops\` PR [#853](https://github.com/openemr/openemr-devops/pull/853) (\`chore(release): update forum template\`, landed 2026-07-15). The website-openemr copy was made in #192 from an earlier version and had drifted post-copy.

## Content changes (byte-identical copy from devops)

- Added OpenEMR logo image at the top
- More descriptive intro (\"which includes new features, improvements, and fixes\")
- Downloads page + professional support links
- Reformatted donation appeal with \`---\` separator + bolder callout

Diff scope: 12 insertions, 4 deletions — one file only.

## Verification

- \`phpunit\` all 9 \`AnnouncementRendererTest\` cases still green (the regression tests for URL escaping + placeholder handling + X-length still pass with the new template content).

## Why it matters

**This sync is a prerequisite for the openemr-devops-side PR that retires \`.github/workflows/release-announcements.yml\` + \`tools/release/{bin,src,tests,templates}/announcement*\`** (openemr/openemr#12598 PR 4 of the announcements slice). Without this sync, retiring devops's copy would silently regress the forum announcement content to the older/simpler shape.

Discovered during PR 4 recon; the smoke-test byte-identity check that validated PR #194 was against devops's July 8 run (pre-#853), which is why the drift didn't show up until now.

## Test plan

- [ ] After merge, re-run the manual smoke test (\`gh workflow run release-announcements.yml --repo openemr/website-openemr -f version=8.2.0 -f tag=v8_2_0 -f branch=rel-820 -f forum_url=\`) and byte-compare the new artifact's \`forum.md\` against devops's most recent 8.2.0 run to confirm parity restored.

Assisted-by: Claude Code