### PR TITLE
docs(announcements): retarget homepage banner from 8.0 to 8.2

### DIFF
--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,6 +1,6 @@
 - title: <strong>New:</strong> Announcing OpenEMR Version 8.2
   url: https://community.open-emr.org/t/openemr-8-2-0-has-just-been-released/26886
-  date: 2026-02-13
+  date: 2026-07-08
   linkText: 💃🕺→
   
 - title: <strong>New:</strong> Free, fully hosted OpenEMR for U.S.-based healthcare providers—no servers, no setup, no cost.

--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,5 +1,5 @@
-- title: <strong>New:</strong> Announcing OpenEMR Version 8
-  url: blog/openemr-version-8-released/
+- title: <strong>New:</strong> Announcing OpenEMR Version 8.2
+  url: https://community.open-emr.org/t/openemr-8-2-0-has-just-been-released/26886
   date: 2026-02-13
   linkText: 💃🕺→
   

--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,5 +1,5 @@
 - title: <strong>New:</strong> Announcing OpenEMR Version 8.2
-  url: https://community.open-emr.org/t/openemr-8-2-0-has-just-been-released/26886
+  url: /downloads
   date: 2026-07-08
   linkText: 💃🕺→
   

--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,5 +1,5 @@
 - title: <strong>New:</strong> Announcing OpenEMR Version 8.2
-  url: /downloads
+  url: downloads
   date: 2026-07-08
   linkText: 💃🕺→
   


### PR DESCRIPTION
## Summary
- Retitle the first banner announcement from "Announcing OpenEMR Version 8" to "Announcing OpenEMR Version 8.2"
- Retarget its link from the local \`blog/openemr-version-8-released/\` post to the community forum thread: https://community.open-emr.org/t/openemr-8-2-0-has-just-been-released/26886

Left the \`date: 2026-02-13\` field untouched — it isn't rendered by the banner partial and is used only for sort/metadata; happy to bump it to the actual 8.2.0 release date (2026-07-08) if we care about accuracy of that field.

## Test plan
- [x] Hugo build clean
- [x] Rendered banner text reads "Announcing OpenEMR Version 8.2"
- [x] Rendered link href = https://community.open-emr.org/t/openemr-8-2-0-has-just-been-released/26886
- [x] Second announcement (opencoreemr hosted) still renders unchanged behind the carousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)