### PR TITLE
ci(release-docs): auto-flip docs PR out of draft on openemr-tag

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -422,6 +422,41 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: task workflow:upsert-pr
 
+      # Post-tag flip: on openemr-tag the docs PR content reflects the
+      # shipped state, so we flip out of draft. Skipped for test-mode
+      # dispatches (branch is release-docs-test/*, PR is ephemeral) and
+      # for pre-tag events (rel-cut/rel-update) that only accumulate
+      # draft-quality content. ship-release's full-auto poll waits on
+      # isDraft==false before merging the docs PR — this step is what
+      # unblocks that wait.
+      - name: Flip docs PR out of draft (openemr-tag only)
+        if: ${{ steps.push.outputs.pushed == 'true' && steps.payload.outputs.event == 'openemr-tag' && steps.mode.outputs.test != 'true' }}
+        env:
+          BRANCH: release-docs/${{ steps.payload.outputs.version }}
+          TAG: ${{ steps.payload.outputs.tag }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr_data="$(gh pr list --repo "$REPO" \
+            --head "$BRANCH" --state open \
+            --json number,isDraft --jq '.[0]')"
+          if [ -z "$pr_data" ] || [ "$pr_data" = 'null' ]; then
+            echo "::error::docs PR for $BRANCH not found; upsert-pr should have created/updated it"
+            exit 1
+          fi
+          pr_number="$(printf '%s' "$pr_data" | jq -r '.number')"
+          is_draft="$(printf '%s' "$pr_data" | jq -r '.isDraft')"
+          # gh pr ready fails if the PR is already out of draft (typical on
+          # a re-fire of openemr-tag after a first successful flip). Guard
+          # with isDraft so re-fires are idempotent.
+          if [ "$is_draft" = 'true' ]; then
+            gh pr ready "$pr_number" --repo "$REPO"
+            gh pr comment "$pr_number" --repo "$REPO" --body \
+              "Comment from Claude: post-tag dispatch applied; content reflects the shipped state for tag \`${TAG}\`. PR flipped out of draft and is ready for merge to master."
+          else
+            echo "PR #${pr_number} is already out of draft; nothing to flip."
+          fi
+
       - name: Sub-dispatch binaries to website-openemr-files
         if: ${{ steps.payload.outputs.files_count != '0' }}
         env:

--- a/tools/release-docs/Taskfile.yml
+++ b/tools/release-docs/Taskfile.yml
@@ -324,7 +324,15 @@ tasks:
     cmds:
       - |
         short_sha="${SHA:0:12}"
-        title="release-docs: OpenEMR ${VERSION} (DRAFT)"
+        # openemr-tag is the post-tag "final content" dispatch — the workflow
+        # flips the PR out of draft in a follow-up step, so the title tracks
+        # that state. rel-cut/rel-update remain "(DRAFT)" while the PR
+        # accumulates pre-tag content.
+        if [ "$EVENT" = 'openemr-tag' ]; then
+          title="release-docs: OpenEMR ${VERSION}"
+        else
+          title="release-docs: OpenEMR ${VERSION} (DRAFT)"
+        fi
         body_file="$RUNNER_TEMP/pr-body.md"
         # shellcheck disable=SC2016
         {


### PR DESCRIPTION
## Summary

- Adds a `Flip docs PR out of draft (openemr-tag only)` step to `release-docs.yml` that runs after `Open or update draft PR`. It looks up the open docs PR by branch (`release-docs/<version>`), flips it via `gh pr ready`, and posts a signal comment.
- Guarded on `steps.payload.outputs.event == 'openemr-tag'` (fires only for the post-tag dispatch, not for pre-tag `openemr-rel-cut` / `openemr-rel-update` events) and on `steps.mode.outputs.test != 'true'` (skips ephemeral `release-docs-test/*` dispatches).
- Idempotent on re-fire: an `isDraft` probe guards the `gh pr ready` + `gh pr comment` calls so re-dispatches of `openemr-tag` don't error out on an already-ready PR.
- Also updates `workflow:upsert-pr` to drop the `(DRAFT)` suffix from the PR title on `openemr-tag` (so the visible title tracks the actual draft flag).

## Why

This closes automation gap step 9 in the release process and unblocks ship-release's full-auto mode from being truly hands-off. Previously, ship-release's poll would time out waiting for `isDraft==false` on the docs PR because no automation flipped it — a maintainer had to click "Ready for review" by hand. Now the openemr-tag dispatch (which fires from openemr/openemr's build-release-on-tag path) does the flip as its last content step, and ship-release full-auto can merge without human intervention.

## Test plan

- [ ] Fire an `openemr-rel-cut` dispatch and confirm the docs PR is still created as draft with `(DRAFT)` in the title.
- [ ] Fire a follow-up `openemr-tag` dispatch and confirm:
  - [ ] Title is updated to `release-docs: OpenEMR <version>` (no `(DRAFT)`).
  - [ ] PR is flipped out of draft (`isDraft: false`).
  - [ ] Signal comment is posted.
- [ ] Re-fire `openemr-tag` and confirm the step is idempotent (no `gh pr ready` error, prints "already out of draft").
- [ ] Fire a test-mode dispatch (branch `rel-test`) and confirm the flip step is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)