### PR TITLE
docs(announcements): retarget homepage banner from 8.2 to 8.3

### DIFF
--- a/data/announcements.yml
+++ b/data/announcements.yml
@@ -1,6 +1,6 @@
-- title: <strong>New:</strong> Announcing OpenEMR Version 8.2
+- title: <strong>New:</strong> Announcing OpenEMR Version 8.3
   url: downloads
-  date: 2026-07-08
+  date: 2026-08-18
   linkText: 💃🕺→
   
 - title: <strong>New:</strong> Free, fully hosted OpenEMR for U.S.-based healthcare providers—no servers, no setup, no cost.


### PR DESCRIPTION
## Summary

- OpenEMR 8.3.0 released today ([tag v8_3_0](https://github.com/openemr/openemr/releases/tag/v8_3_0), published 2026-08-18T07:21:44Z)
- Bump the homepage banner text from "Announcing OpenEMR Version 8.2" to "8.3", and move the `date:` metadata anchor from 2026-07-08 (8.2.0 release) to 2026-08-18 (8.3.0 release)
- `url: downloads` stays as-is (same reasoning as #202)

## Test plan

- [ ] Local `hugo` renders the banner with the 8.3 title
- [ ] After merge, https://www.open-emr.org/ shows the updated banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)